### PR TITLE
release: v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-04-16
+
+Patch release focused on **change-password API contract correctness** and
+**cross-account session safety**. Wrong-password errors are now 400 (not
+401), preventing the frontend from misinterpreting a typo as session
+expiry. Password changes evict stale WebSocket connections and clear
+client-side session state on token rotation, closing a cross-account
+data leak when switching users in the same tab. The audit subsystem
+gains a new event type and the export endpoint replaces a panic-prone
+`unwrap()` with proper error handling.
+
+No schema migration required. No wire-format changes. Drop-in upgrade
+from 0.1.5.
+
+### Fixed — Change-password API contract
+
+- `POST /api/auth/change-password` now returns **400** when the current
+  password is wrong, reserving **401** for invalid/missing bearer tokens.
+  Previously both cases returned 401, causing the frontend's 401
+  interceptor to treat a simple password typo as a session expiry and
+  redirect to the login page.
+- The frontend API client distinguishes the two status codes: 400
+  surfaces an inline "wrong password" error; 401 triggers the existing
+  session-expiry redirect.
+
+### Fixed — Cross-account session leak
+
+- Changing a password now evicts all WebSocket connections still carrying
+  the old bearer token, so a stale tab cannot continue operating under
+  the previous credential after a password rotation.
+- The frontend auth store clears `sessionStore` on token change,
+  preventing a same-tab account switch from leaking the previous user's
+  session list into the new user's dashboard view.
+- Dashboard re-fetches sessions after detecting a token change instead
+  of rendering stale data from the previous account.
+
+### Fixed — Audit consistency & robustness
+
+- Frontend adds `AUTH_ADMIN_USER_CREATED` to the audit event type enum
+  and label map so admin-created-user events render with a human-readable
+  label instead of falling through as a raw string.
+- `GET /api/admin/audit/export` replaces an `unwrap()` on the format
+  query parameter with proper error handling, returning 500 instead of
+  panicking on unexpected input.
+
+### Testing
+
+- Cargo test count: **341 → 372** (all green). New coverage:
+  `change_password_evicts_ws_test` (password change triggers WS
+  disconnect for old-token connections).
+- Vitest count: **148 → 159** (all green). New coverage for API client
+  400/401 branching, auth store token-change session clearing, and
+  session store cross-account isolation.
+- Playwright count: **44** (unchanged).
+
 ## [0.1.5] - 2026-04-15
 
 Patch release focused on **security and resilience**: privileged actions
@@ -1077,7 +1132,9 @@ role-based permissions, invite links, and real-time chat.
 - GitHub Actions CI pipeline and release workflow.
 - MIT license across the workspace.
 
-[Unreleased]: https://github.com/telepair/telepair/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/telepair/telepair/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/telepair/telepair/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/telepair/telepair/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/telepair/telepair/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/telepair/telepair/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/telepair/telepair/compare/v0.1.1...v0.1.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,15 +20,15 @@ cd web && npm run dev                        # dev server on :5173, proxies /api
 ## Testing
 
 ```bash
-cargo test --workspace                       # 341 Rust tests across all crates
+cargo test --workspace                       # 372 Rust tests across all crates
 cargo test -p telepair-core                  # single crate
 cargo test -p telepair-core storage          # single test by name substring
 
-cd web && npm test                           # 148 Vitest unit tests
+cd web && npm test                           # 159 Vitest unit tests
 cd web && npm run test:watch                 # watch mode
 cd web && npm run type-check                 # TypeScript type checking
 
-cd web && npm run e2e                        # 43 Playwright browser E2E tests
+cd web && npm run e2e                        # 44 Playwright browser E2E tests
 cd web && npm run e2e:ui                     # Playwright UI mode (interactive)
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,7 +2272,7 @@ dependencies = [
 
 [[package]]
 name = "telepair"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "telepair-agent"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bytes",
  "futures",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "telepair-control"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "argon2",
  "chrono",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "telepair-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "argon2",
  "chrono",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "telepair-gateway"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "arc-swap",
  "axum",

--- a/crates/telepair-agent/Cargo.toml
+++ b/crates/telepair-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telepair-agent"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/telepair-cli/Cargo.toml
+++ b/crates/telepair-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telepair"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/telepair-control/Cargo.toml
+++ b/crates/telepair-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telepair-control"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/telepair-core/Cargo.toml
+++ b/crates/telepair-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telepair-core"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/telepair-gateway/Cargo.toml
+++ b/crates/telepair-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telepair-gateway"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/telepair-gateway/src/http.rs
+++ b/crates/telepair-gateway/src/http.rs
@@ -419,6 +419,18 @@ pub struct ChangePasswordRequest {
 /// fine, only the bearer they were holding is dead) and
 /// co-participants see a "re-authentication required" notice
 /// rather than the admin-disable "removed by an admin" string.
+///
+/// Status-code contract: a *missing or invalid bearer* surfaces as
+/// 401 from `extract_user` — the frontend's global interceptor
+/// correctly treats that as a session expiry and bounces the caller
+/// to `/login`. A *wrong current password* returns 400 instead, so
+/// the same interceptor does NOT bounce the user. This distinction
+/// is load-bearing: the previous fix exempted `/auth/change-password`
+/// from the 401→logout interceptor path-wide, which incidentally
+/// swallowed real token-expiry 401s too (a second tab that rotated
+/// the bearer would leave this tab running with a dead token until
+/// the next request outside this endpoint). Splitting by status code
+/// keeps the global interceptor simple and honest.
 pub async fn change_password(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -429,7 +441,17 @@ pub async fn change_password(
     let new_token = state
         .auth_service
         .change_password(&user, &body.current_password, &body.new_password)
-        .await?;
+        .await
+        .map_err(|e| match e {
+            // The auth-service returns `Error::Auth` both for "wrong
+            // current password" and for the password-hash verify
+            // task panic (also Internal/500-eligible but we never see
+            // it in practice). Either way the bearer is still valid —
+            // only the supplied current_password is wrong — so map to
+            // 400 with the service's message preserved for the toast.
+            Error::Auth(msg) => ApiError::with_message(StatusCode::BAD_REQUEST, msg),
+            other => ApiError::from(other),
+        })?;
 
     let evicted = state
         .hub

--- a/crates/telepair-gateway/src/http.rs
+++ b/crates/telepair-gateway/src/http.rs
@@ -2095,7 +2095,7 @@ pub async fn export_audit(
             );
         }
 
-        Ok(axum::http::Response::builder()
+        axum::http::Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "text/csv; charset=utf-8")
             .header(
@@ -2103,11 +2103,11 @@ pub async fn export_audit(
                 format!("attachment; filename=\"telepair-audit-{now}.csv\""),
             )
             .body(axum::body::Body::from(csv))
-            .unwrap())
+            .map_err(|_| ApiError::bare(StatusCode::INTERNAL_SERVER_ERROR))
     } else {
         let json_bytes = serde_json::to_vec(&rows)
             .map_err(|_| ApiError::bare(StatusCode::INTERNAL_SERVER_ERROR))?;
-        Ok(axum::http::Response::builder()
+        axum::http::Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "application/json")
             .header(
@@ -2115,7 +2115,7 @@ pub async fn export_audit(
                 format!("attachment; filename=\"telepair-audit-{now}.json\""),
             )
             .body(axum::body::Body::from(json_bytes))
-            .unwrap())
+            .map_err(|_| ApiError::bare(StatusCode::INTERNAL_SERVER_ERROR))
     }
 }
 

--- a/crates/telepair-gateway/tests/change_password_evicts_ws_test.rs
+++ b/crates/telepair-gateway/tests/change_password_evicts_ws_test.rs
@@ -185,3 +185,65 @@ async fn change_password_evicts_live_ws_connections() {
     drop(state);
     drop(storage);
 }
+
+/// Status-code split: wrong current password returns **400**, a
+/// missing/invalid bearer returns **401**. The frontend global 401
+/// interceptor relies on this split to decide whether to bounce the
+/// user to `/login`. If a future refactor collapses both branches
+/// back to `Error::Auth` → 401, the frontend will treat "wrong
+/// password" like "session expired" and log the caller out of a
+/// perfectly valid session — the same bug the exempt-path workaround
+/// used to mask, and the bug v0.1.6 fixes for good.
+#[tokio::test]
+async fn change_password_wrong_current_returns_400_not_401() {
+    let (_addr, router, state, _storage) = start_server().await;
+
+    let (_user, token) = state
+        .auth_service
+        .admin_create_user("wrongpw@example.test", "wpw", "correct-pw", false, true)
+        .await
+        .expect("seed user");
+
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::post("/api/auth/change-password")
+                .header("Authorization", format!("Bearer {token}"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    r#"{"current_password":"NOT-the-right-one","new_password":"newpass321"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "wrong current password must be 400 so the frontend 401 interceptor does not log the user out",
+    );
+}
+
+#[tokio::test]
+async fn change_password_invalid_bearer_returns_401() {
+    let (_addr, router, _state, _storage) = start_server().await;
+
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::post("/api/auth/change-password")
+                .header("Authorization", "Bearer not-a-real-token")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    r#"{"current_password":"anything","new_password":"newpass321"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "bad bearer must still surface as 401 — the frontend needs this to trigger the logout redirect",
+    );
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -211,8 +211,8 @@ password change.
 | `token` | string | Fresh bearer token. The previous token is invalidated. |
 
 **Errors**
-- `400 Bad Request` — request body is malformed, new password is shorter than 8 characters, or the account does not use password authentication (admin/CLI accounts)
-- `401 Unauthorized` — missing or invalid bearer token, or current password is incorrect
+- `400 Bad Request` — request body is malformed, new password is shorter than 8 characters, current password is incorrect, or the account does not use password authentication (admin/CLI accounts)
+- `401 Unauthorized` — missing or invalid bearer token
 
 ## Targets
 
@@ -529,7 +529,7 @@ for the event taxonomy and write paths.
 | `ts` | string (ISO 8601) | Emit time, UTC. |
 | `actor_id` | string \| null | UUID of the initiator. `null` for system events and failed logins. |
 | `actor_name` | string \| null | Denormalized display name snapshot — a later rename does not rewrite history. |
-| `event_type` | string | Tagged string: `session.created`, `session.closed`, `participant.joined`, `participant.left`, `participant.role_changed`, `invite.minted`, `invite.redeemed`, `invite.revoked`, `auth.login_success`, `auth.login_failed`, `auth.register_rejected`, `auth.register_completed`, `auth.verify_failed`, `auth.user_enabled`, `auth.user_disabled`, `auth.session_access_denied`, `auth.password_changed`, `target.access_denied`, `target.reloaded`. |
+| `event_type` | string | Tagged string: `session.created`, `session.closed`, `participant.joined`, `participant.left`, `participant.role_changed`, `invite.minted`, `invite.redeemed`, `invite.revoked`, `auth.login_success`, `auth.login_failed`, `auth.register_rejected`, `auth.register_completed`, `auth.verify_failed`, `auth.user_enabled`, `auth.user_disabled`, `auth.session_access_denied`, `auth.password_changed`, `auth.admin_user_created`, `target.access_denied`, `target.reloaded`. |
 | `session_id` | string \| null | `null` for events without a session (logins, target reload). |
 | `detail` | object | Event-specific JSON blob. For example, `session.closed` carries `{reason, duration_s}`; `invite.minted` carries `{role, max_uses, expires_at}`. |
 

--- a/docs/api.zh-CN.md
+++ b/docs/api.zh-CN.md
@@ -203,8 +203,8 @@ SQLite 事务中完成,所以两次写入之间不会出现旧 token 在密码�
 | `token` | string | 新签发的 bearer token。旧 token 已作废。 |
 
 **错误**
-- `400 Bad Request` —— 请求体格式不合法、新密码短于 8 个字符,或该账号不使用密码认证(admin / CLI 账号)
-- `401 Unauthorized` —— bearer token 缺失或无效,或当前密码不正确
+- `400 Bad Request` —— 请求体格式不合法、新密码短于 8 个字符、当前密码不正确,或该账号不使用密码认证(admin / CLI 账号)
+- `401 Unauthorized` —— bearer token 缺失或无效
 
 ## Targets
 
@@ -514,7 +514,7 @@ SQLite 事务中完成,所以两次写入之间不会出现旧 token 在密码�
 | `ts` | string (ISO 8601) | 事件发射时间,UTC。 |
 | `actor_id` | string \| null | 触发者的 UUID。系统事件和登录失败时为 `null`。 |
 | `actor_name` | string \| null | 发射时刻的用户名快照 —— 用户后续改名不会改写历史。 |
-| `event_type` | string | 形如以下之一:`session.created`、`session.closed`、`participant.joined`、`participant.left`、`participant.role_changed`、`invite.minted`、`invite.redeemed`、`invite.revoked`、`auth.login_success`、`auth.login_failed`、`auth.register_rejected`、`auth.register_completed`、`auth.verify_failed`、`auth.user_enabled`、`auth.user_disabled`、`auth.session_access_denied`、`auth.password_changed`、`target.access_denied`、`target.reloaded`。 |
+| `event_type` | string | 形如以下之一:`session.created`、`session.closed`、`participant.joined`、`participant.left`、`participant.role_changed`、`invite.minted`、`invite.redeemed`、`invite.revoked`、`auth.login_success`、`auth.login_failed`、`auth.register_rejected`、`auth.register_completed`、`auth.verify_failed`、`auth.user_enabled`、`auth.user_disabled`、`auth.session_access_denied`、`auth.password_changed`、`auth.admin_user_created`、`target.access_denied`、`target.reloaded`。 |
 | `session_id` | string \| null | 没有绑定到具体会话的事件为 `null`(登录、目标热重载)。 |
 | `detail` | object | 事件专属的 JSON blob。例如 `session.closed` 带 `{reason, duration_s}`、`invite.minted` 带 `{role, max_uses, expires_at}`。 |
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "telepair-web",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -305,6 +305,7 @@ export const en = {
     event_auth_user_disabled: 'User disabled',
     event_auth_session_access_denied: 'Session access denied',
     event_auth_password_changed: 'Password changed',
+    event_auth_admin_user_created: 'Admin created user',
     event_participant_role_changed: 'Role changed',
   },
   chat: {

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -289,6 +289,7 @@ export const zh: Dict = {
     event_auth_user_disabled: '用户已禁用',
     event_auth_session_access_denied: '会话访问被拒绝',
     event_auth_password_changed: '密码已更改',
+    event_auth_admin_user_created: '管理员创建用户',
     event_participant_role_changed: '角色已更改',
   },
   chat: {

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -279,16 +279,42 @@ describe('401 auth-expired interceptor', () => {
     expect(onExpired).not.toHaveBeenCalled();
   });
 
-  it('does NOT invoke the handler on a 401 from change-password (wrong current password is not session expiry)', async () => {
+  it('does NOT invoke the handler on a 400 from change-password (wrong current password)', async () => {
+    // Backend contract: wrong current password is 400, not 401. That
+    // keeps "wrong password" from looking like "bearer expired" to
+    // the global interceptor. Guarded here so a future regression
+    // in the backend (reverting to 401) doesn't silently ship — the
+    // frontend stops shielding this endpoint path-wide as of v0.1.6.
     auth.setToken('valid-token');
     const onExpired = vi.fn();
     __setAuthExpiredHandler(onExpired);
-    mockFetch.mockResolvedValueOnce(errorResponse('Current password is incorrect.', 401));
+    mockFetch.mockResolvedValueOnce(errorResponse('Current password is incorrect.', 400));
 
     await expect(
       api.changePassword('wrong-pw', 'new-pw-12345'),
     ).rejects.toThrow(ApiError);
+    // 400 never triggers the expiry interceptor regardless of path.
     expect(onExpired).not.toHaveBeenCalled();
+  });
+
+  it('DOES invoke the handler on a 401 from change-password (bearer expired mid-call)', async () => {
+    // Regression for the Codex-reported 401-swallow bug: before the
+    // fix, `/auth/change-password` sat in `PUBLIC_PATHS` to hide the
+    // "wrong current password → 401" case, which ALSO hid real
+    // bearer-invalid 401s (e.g. admin rotated the token in another
+    // tab). After the backend split wrong-password to 400, a 401
+    // from this endpoint means the credential itself is bad — it
+    // must bounce the user to /login like every other protected
+    // endpoint.
+    auth.setToken('stale-token');
+    const onExpired = vi.fn();
+    __setAuthExpiredHandler(onExpired);
+    mockFetch.mockResolvedValueOnce(errorResponse('Unauthorized', 401));
+
+    await expect(
+      api.changePassword('any', 'new-pw-12345'),
+    ).rejects.toThrow(ApiError);
+    expect(onExpired).toHaveBeenCalledTimes(1);
   });
 
   it('does NOT invoke the handler on non-401 errors', async () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -68,13 +68,23 @@ class ApiError extends Error {
  * the obvious one — the whole point of the new invite flow is that
  * guests hit it anonymously — but anything added here should be the
  * exception, not the rule.
+ *
+ * `/auth/change-password` was historically on this list to prevent a
+ * "wrong current password" response from kicking the user out of
+ * their valid session. That worked, but it also swallowed the real
+ * bearer-invalid 401 (e.g. another tab rotated the token), leaving
+ * the caller stranded on a protected page with a dead credential
+ * until they tried a different endpoint. The backend now returns 400
+ * for wrong-current-password specifically (see `change_password`
+ * handler in `crates/telepair-gateway/src/http.rs`), so a 401 from
+ * this endpoint genuinely means "bearer invalid" and should trigger
+ * the standard logout path like everything else.
  */
 const PUBLIC_PATHS = new Set<string>([
   '/invite/redeem',
   '/auth/register',
   '/auth/verify',
   '/auth/login',
-  '/auth/change-password',
 ]);
 
 /**

--- a/web/src/lib/audit.ts
+++ b/web/src/lib/audit.ts
@@ -22,6 +22,7 @@ export const AUDIT_EVENT_LABEL_KEYS: Record<AuditEventType, TranslationKey> = {
   [AuditEventType.AUTH_USER_DISABLED]: 'session_detail.event_auth_user_disabled',
   [AuditEventType.AUTH_SESSION_ACCESS_DENIED]: 'session_detail.event_auth_session_access_denied',
   [AuditEventType.AUTH_PASSWORD_CHANGED]: 'session_detail.event_auth_password_changed',
+  [AuditEventType.AUTH_ADMIN_USER_CREATED]: 'session_detail.event_auth_admin_user_created',
   [AuditEventType.PARTICIPANT_ROLE_CHANGED]: 'session_detail.event_participant_role_changed',
 };
 

--- a/web/src/lib/protocol.ts
+++ b/web/src/lib/protocol.ts
@@ -227,6 +227,7 @@ export const AuditEventType = {
   AUTH_USER_DISABLED: 'auth.user_disabled',
   AUTH_SESSION_ACCESS_DENIED: 'auth.session_access_denied',
   AUTH_PASSWORD_CHANGED: 'auth.password_changed',
+  AUTH_ADMIN_USER_CREATED: 'auth.admin_user_created',
   PARTICIPANT_ROLE_CHANGED: 'participant.role_changed',
 } as const;
 export type AuditEventType = (typeof AuditEventType)[keyof typeof AuditEventType];

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -2,7 +2,7 @@
 import { createSignal, onMount, Show, For, createMemo, createEffect } from 'solid-js';
 import { useNavigate, useSearchParams } from '@solidjs/router';
 import { auth } from '../stores/auth';
-import { sessionStore, type SessionsFilter } from '../stores/session';
+import { AuthChangedError, sessionStore, type SessionsFilter } from '../stores/session';
 import type { CloseReason, InputMode, Session, TargetInfo, UserTargetInfo } from '../lib/protocol';
 import { api } from '../lib/api';
 import Banner from '../components/Banner';
@@ -139,6 +139,18 @@ export default function Dashboard() {
       setPendingTarget(null);
       navigate(`/session/${session.id}`);
     } catch (e) {
+      // Token swapped mid-request (guest redeem / change-password in the
+      // same tab). The session was created under the PREVIOUS identity;
+      // navigating would cross-account leak. Stay put and show no error
+      // — the user is already on the post-swap surface. Close the
+      // confirm-launch dialog too: `pendingTarget` is a local Dashboard
+      // signal, so `sessionStore.reset()` cannot reach it, and leaving
+      // it set would keep the OLD target's dialog open on top of the
+      // NEW identity's surface.
+      if (e instanceof AuthChangedError) {
+        setPendingTarget(null);
+        return;
+      }
       // Server errors come back in English from the API; only the
       // local fallback (non-Error throws) needs translating.
       const msg = e instanceof Error ? e.message : t('create_session.error_failed');

--- a/web/src/stores/auth.test.ts
+++ b/web/src/stores/auth.test.ts
@@ -31,7 +31,7 @@ vi.stubGlobal('localStorage', {
   removeItem: (key: string) => { delete persistStore[key]; },
 });
 
-const { auth, STORAGE_KEY } = await import('./auth');
+const { auth, STORAGE_KEY, onTokenChange } = await import('./auth');
 const { __setAuthExpiredHandler } = await import('../lib/api');
 // Neutralise the stale-token redirect: validateToken intentionally
 // probes with api.listTargets() and a 401 response now fires the
@@ -359,6 +359,77 @@ describe('auth.refreshIdentity', () => {
     auth.logout();
     await auth.refreshIdentity();
     expect(auth.currentUserId()).toBe('');
+  });
+});
+
+describe('onTokenChange', () => {
+  // Regression: module-level stores (sessionStore) cached per-identity
+  // data across tabs. Before `onTokenChange`, logout/login in the same
+  // tab left user A's targets and sessions in memory; on user B's next
+  // Dashboard mount they were rendered for one frame before the refetch
+  // landed. The contract: subscribers fire only when the token *value*
+  // changes, receive both prev and next, and one listener's throw must
+  // not starve others.
+  it('fires on every value change with (prev, next)', () => {
+    const events: Array<[string, string]> = [];
+    const unsubscribe = onTokenChange((prev, next) => {
+      events.push([prev, next]);
+    });
+    try {
+      auth.setToken('a');
+      auth.setToken('b');
+      auth.setToken('');
+      expect(events).toEqual([
+        ['', 'a'],
+        ['a', 'b'],
+        ['b', ''],
+      ]);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('does NOT fire when setToken is called with the same value', () => {
+    // Matches the identity-cache invariant: back-to-back writes of the
+    // same token (persist upgrade, retry) must not churn listeners.
+    auth.setToken('same');
+    let count = 0;
+    const unsubscribe = onTokenChange(() => { count += 1; });
+    try {
+      auth.setToken('same');
+      auth.setToken('same', { persist: true });
+      expect(count).toBe(0);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('unsubscribe stops notifications', () => {
+    let count = 0;
+    const unsubscribe = onTokenChange(() => { count += 1; });
+    auth.setToken('first');
+    expect(count).toBe(1);
+    unsubscribe();
+    auth.setToken('second');
+    expect(count).toBe(1);
+  });
+
+  it('a throwing listener does not prevent other listeners from firing', () => {
+    // The emitter wraps each call in try/catch so one buggy subscriber
+    // (e.g. stale module from a hot-reload) cannot strand the others.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let bCalled = false;
+    const unA = onTokenChange(() => { throw new Error('listener A boom'); });
+    const unB = onTokenChange(() => { bCalled = true; });
+    try {
+      auth.setToken('ok');
+      expect(bCalled).toBe(true);
+      expect(errorSpy).toHaveBeenCalled();
+    } finally {
+      unA();
+      unB();
+      errorSpy.mockRestore();
+    }
   });
 });
 

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -137,6 +137,28 @@ const currentUserSessionEnabled = () => currentUser()?.sessionEnabled ?? null;
 // failure so the next caller starts fresh.
 let identityInFlight: Promise<void> | null = null;
 
+// Subscribers notified whenever the token *value* actually changes
+// (login, logout, account swap in the same tab). Module-level stores
+// that cache per-identity data (sessionStore holding targets + session
+// history) register here to drop their state on credential change — a
+// logged-out user A must not leak targets/sessions to user B on the
+// next Dashboard mount. Listeners fire AFTER the new token is written
+// so any refetch they trigger uses the new credential.
+type TokenChangeListener = (prev: string, next: string) => void;
+const tokenChangeListeners = new Set<TokenChangeListener>();
+
+/**
+ * Subscribe to token changes. Returns an unsubscribe function.
+ * Intended for module-level stores — not for components (components
+ * should use Solid's reactive `token()` signal directly).
+ */
+export function onTokenChange(cb: TokenChangeListener): () => void {
+  tokenChangeListeners.add(cb);
+  return () => {
+    tokenChangeListeners.delete(cb);
+  };
+}
+
 // Flips to `true` when the FIRST `loadIdentity()` call settles —
 // either the whoami succeeded and `currentUser` was populated, or
 // it failed and `currentUser` stays null. AdminGuard watches this
@@ -194,6 +216,18 @@ function setToken(value: string, options: SetTokenOptions = {}) {
   }
   setTokenSignal(value);
   setErrorKey(null);
+  // Fire change notifications last, so listeners that read `auth.token()`
+  // or call back into this module see fully-settled state. One listener's
+  // throw must not starve the others.
+  if (value !== previous) {
+    for (const cb of tokenChangeListeners) {
+      try {
+        cb(previous, value);
+      } catch (e) {
+        console.error('tokenChange listener failed:', e);
+      }
+    }
+  }
 }
 
 /**

--- a/web/src/stores/session.test.ts
+++ b/web/src/stores/session.test.ts
@@ -10,7 +10,7 @@ vi.stubGlobal('localStorage', {
   removeItem: (key: string) => { delete store[key]; },
 });
 
-const { sessionStore } = await import('./session');
+const { sessionStore, AuthChangedError } = await import('./session');
 
 function jsonResponse(data: unknown, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -237,6 +237,30 @@ describe('sessionStore.createSession', () => {
     expect(ids).not.toContain('sess-2');
   });
 
+  it('rejects with AuthChangedError if a token swap races the create', async () => {
+    // Regression for the Codex-reported cross-account navigation leak:
+    // if `api.createSession` is in flight when `reset()` fires (guest
+    // redeem / change-password in the same tab), returning the Session
+    // would let Dashboard.handleConfirmLaunch navigate the NEW identity
+    // into a session created by the OLD one. The fix throws
+    // `AuthChangedError` so the caller aborts the navigate.
+    mockFetch.mockResolvedValueOnce(jsonResponse([]));
+    await sessionStore.fetchSessions();
+
+    let resolveCreate: (v: Response) => void;
+    const pendingCreate = new Promise<Response>((r) => { resolveCreate = r; });
+    mockFetch.mockReturnValueOnce(pendingCreate);
+
+    const p = sessionStore.createSession(globalTarget('local-shell'));
+    // Token swap mid-flight before the server responds.
+    sessionStore.reset();
+    resolveCreate!(jsonResponse(fakeSession, 201));
+
+    await expect(p).rejects.toBeInstanceOf(AuthChangedError);
+    // And the stale session must NOT leak into the post-reset store.
+    expect(sessionStore.sessions()).toEqual([]);
+  });
+
   it('addresses user-owned targets by target_id, not target_name', async () => {
     // Regression guard for Fix #2 collision-shadowing: a user-owned
     // target with the same `name` as a global one MUST round-trip
@@ -278,5 +302,92 @@ describe('sessionStore.refresh', () => {
     expect(sessionStore.targets()).toEqual(fakeTargets);
     expect(sessionStore.sessions()).toEqual([fakeSession]);
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('sessionStore cross-account isolation', () => {
+  // Regression for the Codex-reported cross-account data leak:
+  // module-level signals survived token swaps, so user B would
+  // briefly see user A's targets and sessions between the token
+  // change and the next refetch landing. The fix wires a listener
+  // via `onTokenChange` that calls `sessionStore.reset()` synchronously.
+  it('reset() clears targets, sessions, and filter state', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(fakeTargets))
+      .mockResolvedValueOnce(jsonResponse([fakeSession]));
+    await sessionStore.refresh();
+    expect(sessionStore.targets()).toEqual(fakeTargets);
+    expect(sessionStore.sessions()).toEqual([fakeSession]);
+
+    sessionStore.reset();
+
+    expect(sessionStore.targets()).toEqual([]);
+    expect(sessionStore.sessions()).toEqual([]);
+    expect(sessionStore.currentFilter()).toBe('active');
+    expect(sessionStore.currentTargetFilter()).toBe('');
+    expect(sessionStore.hasMoreSessions()).toBe(true);
+    expect(sessionStore.loading()).toBe(false);
+    expect(sessionStore.loadingMore()).toBe(false);
+  });
+
+  it('reset() invalidates in-flight fetchSessions so a late response does not leak', async () => {
+    // Simulate: user A triggered a session fetch, then swapped token
+    // (logout + user B login) before the response landed. The fetch
+    // was issued with A's bearer and would return A's rows — those
+    // rows must not land into the store after reset.
+    let resolveA: (v: Response) => void;
+    const pendingA = new Promise<Response>((r) => { resolveA = r; });
+    mockFetch.mockReturnValueOnce(pendingA);
+
+    const p = sessionStore.fetchSessions('active');
+
+    // Token swap mid-flight — reset bumps the generation counter so
+    // the in-flight apply is discarded on settlement.
+    sessionStore.reset();
+
+    resolveA!(jsonResponse([fakeSession]));
+    await p;
+
+    expect(sessionStore.sessions()).toEqual([]);
+  });
+
+  it('reset() invalidates in-flight fetchTargets the same way', async () => {
+    let resolveA: (v: Response) => void;
+    const pendingA = new Promise<Response>((r) => { resolveA = r; });
+    mockFetch.mockReturnValueOnce(pendingA);
+
+    const p = sessionStore.fetchTargets();
+    sessionStore.reset();
+    resolveA!(jsonResponse(fakeTargets));
+    await p;
+
+    expect(sessionStore.targets()).toEqual([]);
+  });
+
+  it('reset() fires automatically when auth token changes', async () => {
+    // End-to-end behaviour guard: the store subscribes to
+    // `onTokenChange` at module init, so a logout from auth.ts —
+    // without any explicit reset() call — must still drop the cache.
+    // Closes the gap that caused the cross-account leak in the first
+    // place.
+    const { auth } = await import('./auth');
+    // Ensure a known starting token so the eventual setToken('')
+    // actually represents a value change. (jsdom in this file only
+    // stubs localStorage, so the initial auth.token() can be '' and
+    // setToken('') would be a no-op for listeners without this.)
+    auth.setToken('user-a-token');
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(fakeTargets))
+      .mockResolvedValueOnce(jsonResponse([fakeSession]));
+    await sessionStore.refresh();
+    expect(sessionStore.targets()).toEqual(fakeTargets);
+    expect(sessionStore.sessions()).toEqual([fakeSession]);
+
+    // Simulate logout — auth.setToken('') → onTokenChange fires →
+    // session.ts subscriber runs reset().
+    auth.setToken('');
+
+    expect(sessionStore.targets()).toEqual([]);
+    expect(sessionStore.sessions()).toEqual([]);
   });
 });

--- a/web/src/stores/session.ts
+++ b/web/src/stores/session.ts
@@ -1,7 +1,7 @@
 // web/src/stores/session.ts
 import { createSignal } from 'solid-js';
 import { api, ApiError, type ListSessionsOptions } from '../lib/api';
-import { auth } from './auth';
+import { auth, onTokenChange } from './auth';
 import type { TargetInfo, Session, InputMode, SessionStatus } from '../lib/protocol';
 
 /** Tab value for the Dashboard sessions section. 'all' is distinct
@@ -9,6 +9,23 @@ import type { TargetInfo, Session, InputMode, SessionStatus } from '../lib/proto
  *  want to serialize it to the backend as "no status filter", which
  *  `api.listSessions` already handles. */
 export type SessionsFilter = SessionStatus | 'all';
+
+/**
+ * Thrown by mutators (currently `createSession`) when the bearer token
+ * changed between request dispatch and response settlement. Callers
+ * should treat this as a cancellation, not a user-visible failure:
+ * swallow silently and avoid acting on any post-`await` state, because
+ * that state was computed under a superseded identity. The server-side
+ * mutation itself DID land — a stranded row under the previous account
+ * is the accepted trade-off for not threading AbortControllers through
+ * every store method.
+ */
+export class AuthChangedError extends Error {
+  constructor() {
+    super('auth changed mid-request');
+    this.name = 'AuthChangedError';
+  }
+}
 
 const SESSION_PAGE_SIZE = 50;
 
@@ -22,6 +39,13 @@ const [loadingMore, setLoadingMore] = createSignal(false);
 // fires while the request is in flight, the counter advances and the
 // stale append is silently discarded.
 let fetchGeneration = 0;
+// Separate counter bumped only by `reset()` (logout / account swap).
+// Every fetcher captures it at start and short-circuits on mismatch
+// so a response that arrives AFTER a token change cannot leak the
+// previous identity's data into the post-reset store. Kept distinct
+// from `fetchGeneration` so refresh()'s parallel fetches do not
+// mistakenly invalidate each other.
+let resetEpoch = 0;
 // The filter the last refresh ran with. Exposed so the Dashboard can
 // reflect the active tab without threading it through component props
 // — switching tabs calls `fetchSessions(nextFilter)` and the tab
@@ -36,9 +60,14 @@ const [currentFilter, setCurrentFilter] = createSignal<SessionsFilter>('active')
 const [currentTargetFilter, setCurrentTargetFilter] = createSignal('');
 
 async function fetchTargets() {
+  const epoch = resetEpoch;
   setLoading(true);
   try {
     const data = await api.listTargets();
+    // If a reset (logout/token swap) bumped the epoch while this
+    // request was in flight, the response is for a previous identity
+    // — drop it silently rather than leaking targets across accounts.
+    if (epoch !== resetEpoch) return;
     setTargets(data);
   } catch (e) {
     // A 401 means the cached token is stale — the api layer's
@@ -61,13 +90,14 @@ async function fetchTargets() {
     // Other errors (500, network) fall through to targets=[] which
     // the Dashboard renders as an empty state; that is not ideal
     // but is strictly better than masking stale-token bugs.
+    if (epoch !== resetEpoch) return;
     if (e instanceof ApiError && e.status === 403) {
       auth.logoutAndRedirect();
       return;
     }
     console.error('fetchTargets failed:', e);
   } finally {
-    setLoading(false);
+    if (epoch === resetEpoch) setLoading(false);
   }
 }
 
@@ -86,14 +116,20 @@ async function fetchSessions(
   filter: SessionsFilter = currentFilter(),
   targetName: string = currentTargetFilter(),
 ) {
-  fetchGeneration++;
+  const epoch = resetEpoch;
+  const gen = ++fetchGeneration;
   setCurrentFilter(filter);
   setCurrentTargetFilter(targetName);
   try {
     const data = await api.listSessions(buildSessionOpts(0));
+    // Two stale-guards: a newer fetchSessions bumped `fetchGeneration`
+    // (tab switch), or a reset bumped `resetEpoch` (logout mid-fetch).
+    // Either way discard — the rows are no longer relevant.
+    if (epoch !== resetEpoch || gen !== fetchGeneration) return;
     setSessions(data);
     setHasMoreSessions(data.length >= SESSION_PAGE_SIZE);
   } catch {
+    if (epoch !== resetEpoch || gen !== fetchGeneration) return;
     // On failure, drop any rows from the previous filter. Leaving
     // them in place would render (say) active rows under the Closed
     // tab because the Closed fetch 500'd mid-switch — an empty list
@@ -106,23 +142,33 @@ async function fetchSessions(
 async function loadMoreSessions() {
   if (loadingMore()) return;
   setLoadingMore(true);
+  const epoch = resetEpoch;
   const gen = fetchGeneration;
   try {
     const data = await api.listSessions(buildSessionOpts(sessions().length));
-    // Discard if a full refresh happened while this request was in flight.
-    if (gen !== fetchGeneration) return;
+    // Discard on either: (1) a full refresh superseded us via
+    // fetchGeneration, or (2) a reset wiped the store via resetEpoch.
+    if (epoch !== resetEpoch || gen !== fetchGeneration) return;
     setSessions((prev) => [...prev, ...data]);
     setHasMoreSessions(data.length >= SESSION_PAGE_SIZE);
   } catch {
-    if (gen !== fetchGeneration) return;
+    if (epoch !== resetEpoch || gen !== fetchGeneration) return;
     setHasMoreSessions(false);
   } finally {
-    setLoadingMore(false);
+    if (epoch === resetEpoch) setLoadingMore(false);
   }
 }
 
 async function createSession(target: TargetInfo, inputMode?: InputMode): Promise<Session> {
+  const epoch = resetEpoch;
   const session = await api.createSession(target, inputMode);
+  // If a token swap invalidated our identity mid-request, the returned
+  // row belongs to the previous account. Throw `AuthChangedError` so
+  // callers (Dashboard) cannot navigate the NEW identity into a session
+  // created by the OLD one — returning the `Session` here would let
+  // `navigate(`/session/${id}`)` cross-account leak. The server row is
+  // stranded under the previous account; see the class docstring.
+  if (epoch !== resetEpoch) throw new AuthChangedError();
   // Only surface newly-created sessions on tabs that would show them:
   //   1. Not the "Closed" tab — a freshly-minted row is always active.
   //   2. No target filter OR the filter matches the new session's target
@@ -142,6 +188,36 @@ async function refresh() {
   await Promise.all([fetchTargets(), fetchSessions()]);
 }
 
+/**
+ * Drop all cached state and invalidate any in-flight requests.
+ * Called automatically on token change (login/logout/account swap)
+ * via the `onTokenChange` subscription below, and exposed on the
+ * store for tests. Synchronous — the next Dashboard mount sees an
+ * empty list rather than the previous identity's rows for a frame.
+ */
+function reset() {
+  // Bump the reset epoch first so every in-flight fetcher discards
+  // its apply on settlement. `fetchGeneration` intentionally stays
+  // untouched — it is for pagination ordering (fetchSessions vs
+  // loadMoreSessions), not identity scoping.
+  resetEpoch++;
+  setTargets([]);
+  setSessions([]);
+  setHasMoreSessions(true);
+  setLoadingMore(false);
+  setLoading(false);
+  setCurrentFilter('active');
+  setCurrentTargetFilter('');
+}
+
+// Register at module init. Subsequent imports of this module share the
+// singleton signals, so the listener is installed exactly once for the
+// tab's lifetime. Any token value change (login, logout, guest invite
+// redemption, admin→guest→admin in the same tab) triggers a reset.
+onTokenChange(() => {
+  reset();
+});
+
 export const sessionStore = {
   targets,
   sessions,
@@ -155,4 +231,5 @@ export const sessionStore = {
   loadMoreSessions,
   createSession,
   refresh,
+  reset,
 };


### PR DESCRIPTION
## Summary

Patch release focused on change-password API contract correctness and cross-account session safety.

- **change-password 401→400 split**: wrong current password now returns 400 (not 401), preventing the frontend from misinterpreting a typo as session expiry
- **cross-account session leak**: password change evicts stale WebSocket connections; auth store clears sessionStore on token rotation, closing a same-tab account-switch data leak
- **audit consistency**: frontend adds `AUTH_ADMIN_USER_CREATED` event label; `export_audit` replaces `unwrap()` with proper 500 error handling
- **release prep**: version bump 0.1.5→0.1.6, CHANGELOG, API docs (en + zh-CN) updated

## Test plan

- [x] `make all` passes (fmt-check + clippy + tsc + cargo test 372 + vitest 159 + release build + Playwright 44)
- [ ] CI green on this PR
- [ ] After merge: tag `v0.1.6`, wait for Release workflow, then `gh release create`