### PR TITLE
v0.1.8: session recording + auth/share-link security pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test-reports/
 /package.json
 /package-lock.json
 .claude/
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-04-17
+
+Minor release centred on **session recording and playback**. Live
+sessions can be captured as asciicast v2 `.cast` files on demand,
+replayed in the browser with play / pause / seek / speed controls, and
+shared via public signed links with configurable expiry and use
+quotas. The subsystem ships with a streaming writer (1 s timer /
+64 KiB threshold flush), a TTL background cleaner, full REST +
+WebSocket + CLI surfaces, and a collaboration-aware playback UI that
+replays participants and chat timelines in step with PTY output.
+
+The release also lands a focused **security pass** on the auth and
+share-link paths — per-IP throttling now covers `/api/auth/login` and
+`/api/auth/verify` (previously only `/api/auth/register`), share-link
+revocation URLs carry the SHA-256 digest instead of the raw token,
+and share-token validation runs as a single atomic
+`UPDATE … RETURNING` closing a TOCTOU race on `max_uses`.
+
+Two new tables (`recordings`, `recording_shares`) are applied
+idempotently at boot. Two new additive `ServerMessage` variants
+(`RecordingStarted`, `RecordingStopped`) and two new audit event
+types (`recording.started`, `recording.stopped`) land on the wire;
+no existing message, column, or response shape changes. Drop-in
+upgrade from 0.1.7.
+
 ### Added — Session recording
 
 - New session recording subsystem: opt-in `.cast` (asciicast v2)
@@ -77,6 +102,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   across the `.send().await` to the writer — under back-pressure
   the previous code blocked every concurrent write-lock acquirer
   for the duration of the flush handshake.
+
+### Testing
+
+- Cargo test count: **372 → 409** (all green). New coverage:
+  `recording_test` (asciicast v2 encode/decode round-trip,
+  `Recording` lifecycle, share-token hashing), `recording_storage_test`
+  (atomic `UPDATE … RETURNING` consumption, TTL cleaner row+file
+  parity, cross-recording token quota isolation), and gateway-level
+  REST coverage for the recording endpoints and access-control gates.
+- Vitest count: **185 → 194** (all green). New coverage:
+  `playback.test.ts` for the PlaybackEngine asciicast v2 parser and
+  play/pause/seek/speed state machine.
+- Playwright count: **44 → 51** (all green). New spec
+  `recording.spec.ts` exercises the owner start/stop flow, the live
+  indicator broadcast to peers, the share-link dialog, and the
+  anonymous `?token=` playback path outside `AuthGuard`.
 
 ## [0.1.7] - 2026-04-16
 
@@ -1266,7 +1307,8 @@ role-based permissions, invite links, and real-time chat.
 - GitHub Actions CI pipeline and release workflow.
 - MIT license across the workspace.
 
-[Unreleased]: https://github.com/telepair/telepair/compare/v0.1.7...HEAD
+[Unreleased]: https://github.com/telepair/telepair/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/telepair/telepair/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/telepair/telepair/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/telepair/telepair/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/telepair/telepair/compare/v0.1.4...v0.1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the previous code blocked every concurrent write-lock acquirer
   for the duration of the flush handshake.
 
+## [0.1.7] - 2026-04-16
+
+Patch release focused on **terminal personalization and out-of-tab
+awareness**: the session page gains a settings panel for theme, font,
+and cursor style (all persisted in `localStorage`), and a browser-
+notification path surfaces chat messages and peer joins when the tab
+is hidden. Web-only change — no backend, schema, or wire-format impact.
+Drop-in upgrade from 0.1.6.
+
+### Added — Terminal settings panel
+
+- New `SettingsPanel` in the session topbar with a gear affordance,
+  click-outside dismissal, and full keyboard access.
+- Five bundled color themes (`github-dark`, `github-light`, `dracula`,
+  `monokai`, `solarized-dark`) rendered as live swatches so the preview
+  matches exactly what xterm.js will show.
+- Font size stepper (10–24 px) and font-family picker across five
+  bundled monospace families (`jetbrains-mono`, `fira-code`,
+  `source-code-pro`, `cascadia-code`, `system-mono`).
+- Cursor style selector (`block` / `underline` / `bar`) plus a blink
+  toggle, both applied to the live xterm instance without reconnect.
+- All settings persist in `localStorage` and restore on next page
+  load; stored values are validated against the allowed set so a
+  manually edited storage entry cannot poison the terminal with an
+  unknown theme or font id.
+- `settings` i18n namespace added to both `en.ts` and `zh.ts` with
+  parity enforced by the existing dict-symmetry test.
+
+### Added — Browser notifications
+
+- Opt-in browser notifications fire on **incoming chat messages** and
+  **peer-join** events while the tab is backgrounded (`document.hidden`),
+  so collaborators are not missed when the terminal is not focused.
+- Notifications are gated on user consent: the settings panel requests
+  `Notification.requestPermission()` on first toggle and surfaces a
+  `warning` toast when the browser denies the prompt, so the UI never
+  silently flips back to "disabled" without telling the user why.
+- No notifications are emitted while the tab has focus, and permission
+  state is re-checked on every toggle so revoking at the browser level
+  is picked up without a reload.
+
+### Fixed
+
+- The collaboration sidebar auto-closes on narrow viewports so the
+  terminal stays visible on phones and split-pane layouts instead of
+  being pushed off-screen by the participants / chat pane.
+- The persisted `cursorBlink` value is restored after a viewer→operator
+  unlock, closing a small regression where the cursor would stop
+  blinking even though the stored setting said it should.
+- Stored settings are validated against the allowed theme / font /
+  cursor-style enums before being applied, so a stale or manually
+  edited `localStorage` entry no longer leaves the terminal in an
+  undefined visual state.
+
+### Testing
+
+- Vitest count: **159 → 185** (all green). New coverage:
+  `notifications.test.ts` (permission flow, tab-hidden gating,
+  unsupported-browser fallback) and `stores/settings.test.ts`
+  (persistence, validation, cursor-style round-trip, reset).
+- Cargo test count: **372** (unchanged — web-only release).
+- Playwright count: **44** (unchanged).
+
 ## [0.1.6] - 2026-04-16
 
 Patch release focused on **change-password API contract correctness** and
@@ -1203,7 +1266,8 @@ role-based permissions, invite links, and real-time chat.
 - GitHub Actions CI pipeline and release workflow.
 - MIT license across the workspace.
 
-[Unreleased]: https://github.com/telepair/telepair/compare/v0.1.6...HEAD
+[Unreleased]: https://github.com/telepair/telepair/compare/v0.1.7...HEAD
+[0.1.7]: https://github.com/telepair/telepair/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/telepair/telepair/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/telepair/telepair/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/telepair/telepair/compare/v0.1.3...v0.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@ The release also lands a focused **security pass** on the auth and
 share-link paths — per-IP throttling now covers `/api/auth/login` and
 `/api/auth/verify` (previously only `/api/auth/register`), share-link
 revocation URLs carry the SHA-256 digest instead of the raw token,
-and share-token validation runs as a single atomic
-`UPDATE … RETURNING` closing a TOCTOU race on `max_uses`.
+share-token validation runs as a single atomic `UPDATE … RETURNING`
+closing a TOCTOU race on `max_uses`, and share revoke itself is now
+scoped by `(recording_id, token_sha256)` so one owner cannot revoke
+another owner's share links by computing their SHA-256 from the
+(non-secret) raw URL.
 
 Two new tables (`recordings`, `recording_shares`) are applied
 idempotently at boot. Two new additive `ServerMessage` variants
@@ -71,6 +74,15 @@ upgrade from 0.1.7.
   one statement. The previous read-then-update sequence had a TOCTOU
   race on `max_uses` and let any holder of one recording's token
   burn quota by hitting another recording's URL.
+- `DELETE /api/recordings/:id/shares/:token_sha256` now scopes the
+  delete to `(recording_id, token_sha256)` at the storage layer
+  instead of by digest alone. Before the fix, any owner who learned
+  a share link (the raw token is the link itself — not a secret)
+  could compute its SHA-256 and revoke it by hitting the endpoint
+  under their own `recording_id` in the URL, enabling cross-owner
+  share revocation. A mismatched `(recording_id, token_sha256)` pair
+  now returns 404, making cross-owner revoke indistinguishable from
+  a truly unknown digest.
 
 ### Fixed
 
@@ -102,14 +114,34 @@ upgrade from 0.1.7.
   across the `.send().await` to the writer — under back-pressure
   the previous code blocked every concurrent write-lock acquirer
   for the duration of the flush handshake.
+- `DELETE /api/recordings/:id` refuses (409) while the recording is
+  still being captured (`status = 'recording'`). The previous code
+  removed the file and DB row from under the live writer, leaving a
+  dangling file handle, wedging `stop_recording` into a 404, and
+  keeping the hub's recording slot occupied until the session ended.
+  File removal no longer proceeds when the status check fails, and
+  IO errors other than `NotFound` bubble up so the DB row survives
+  for a retry instead of leaving an orphan on disk.
+- The TTL background cleaner excludes `status = 'recording'` rows
+  from its expiry scan, belt-and-suspenders defence against a bad
+  `expires_at` write or wall-clock jump handing it an active row.
+- Recording writer marks the capture `failed` instead of `completed`
+  when any PTY / collab events were dropped under back-pressure.
+  Previously `try_send` failures were swallowed and the final status
+  was always `completed`, so viewers could load a capture with
+  invisible gaps. The hub's recording slot now bundles the mpsc
+  sender with a shared `AtomicU64` drop counter, and the writer
+  reads it at finalisation — a non-zero count flips the status and
+  logs the drop total at `error!` level.
 
 ### Testing
 
-- Cargo test count: **372 → 409** (all green). New coverage:
+- Cargo test count: **372 → 416** (all green). New coverage:
   `recording_test` (asciicast v2 encode/decode round-trip,
   `Recording` lifecycle, share-token hashing), `recording_storage_test`
   (atomic `UPDATE … RETURNING` consumption, TTL cleaner row+file
-  parity, cross-recording token quota isolation), and gateway-level
+  parity, cross-recording token quota isolation, cross-owner share-
+  revoke rejection, delete-while-active guard), and gateway-level
   REST coverage for the recording endpoints and access-control gates.
 - Vitest count: **185 → 194** (all green). New coverage:
   `playback.test.ts` for the PlaybackEngine asciicast v2 parser and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Session recording
+
+- New session recording subsystem: opt-in `.cast` (asciicast v2)
+  capture of every active session, with a streaming writer that
+  flushes on a 1 s timer or 64 KiB threshold and a TTL background
+  task that purges expired recordings.
+- REST surface for recordings: `POST /api/sessions/:id/recording/{start,stop}`,
+  `GET /api/recordings`, `GET /api/recordings/:id`, `GET /api/recordings/:id/data`,
+  `DELETE /api/recordings/:id`, `POST /api/recordings/:id/{keep,expire}`,
+  plus share-link CRUD at `/api/recordings/:id/shares` and a public
+  `?token=` access path on the `/data` endpoint.
+- Browser playback page powered by xterm.js with play / pause /
+  seek / speed controls, a participant + chat sidebar replayed in
+  step with PTY output, and an event timeline of the recorded
+  collab messages.
+- WebSocket `RecordingStarted` / `RecordingStopped` server messages
+  so every connected client surfaces the live indicator.
+- New audit event types `recording.started` / `recording.stopped`
+  written by the gateway and rendered in the admin audit timeline.
+- New CLI flags `--recording-enabled`, `--recording-dir`,
+  `--recording-ttl-days` (and matching `TELEPAIR_*` env vars), with
+  `--recording-enabled=false` now actually rejecting `start_recording`
+  requests at the HTTP layer.
+
+### Security
+
+- `POST /api/auth/login` and `POST /api/auth/verify` now share the
+  per-IP throttle that already protected `/api/auth/register`,
+  closing a credential-stuffing / OTP brute-force gap (the
+  per-account 5-strike lockout and per-email OTP throttle were not
+  enough on their own).
+- `DELETE /api/recordings/:id/shares/:token_sha256` now takes the
+  SHA-256 digest in the URL — putting the raw share token in the
+  path leaked it into access logs and Referer headers.
+- Share-token validation runs as a single `UPDATE … RETURNING` that
+  checks expiry, remaining uses, and the requested recording id in
+  one statement. The previous read-then-update sequence had a TOCTOU
+  race on `max_uses` and let any holder of one recording's token
+  burn quota by hitting another recording's URL.
+
+### Fixed
+
+- Recording id is now generated once in `RecordingService` and
+  reused as the on-disk filename, the asciicast `telepair` block,
+  and the DB primary key. Previously the storage layer minted its
+  own id, so `RecordingRow.id` and `file_path` referred to
+  different recordings and the TTL cleaner deleted the row but
+  left the `.cast` file behind.
+- Anonymous share playback works: `/recordings/:id/play` is now a
+  dedicated route outside `AuthGuard`, so a recipient with a
+  `?token=` link is not bounced to `/login`.
+- Revoking a share link actually removes the row. The HTTP handler
+  previously called `delete_share` with the SHA-256 digest from the
+  UI, which the service then re-hashed before lookup; the
+  `DELETE … WHERE token_sha256 = ?` saw nothing and returned 204
+  while the link kept working.
+- Recording dimensions reflect the actual PTY size: the start
+  handler now reads `(cols, rows)` from the live session instead of
+  hardcoding `80×24`, and the PTY I/O loop keeps the size in sync
+  on every resize.
+- Writer-task I/O failures release the hub's recording slot so the
+  owner can stop and restart recording in the same session — the
+  previous behaviour stranded the slot bound to a dead writer until
+  the session itself ended.
+- Player seek uses `term.reset()` instead of `term.clear()` so
+  rewinding does not stack the old run into the scrollback buffer.
+- `stop_recording` no longer holds the sessions `RwLock` read guard
+  across the `.send().await` to the writer — under back-pressure
+  the previous code blocked every concurrent write-lock acquirer
+  for the duration of the flush handshake.
+
 ## [0.1.6] - 2026-04-16
 
 Patch release focused on **change-password API contract correctness** and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,7 +2272,7 @@ dependencies = [
 
 [[package]]
 name = "telepair"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "telepair-agent"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "bytes",
  "futures",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "telepair-control"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "argon2",
  "chrono",
@@ -2328,7 +2328,7 @@ dependencies = [
 
 [[package]]
 name = "telepair-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "argon2",
  "bytes",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "telepair-gateway"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,11 +2312,15 @@ version = "0.1.7"
 dependencies = [
  "argon2",
  "chrono",
+ "hex",
  "lettre",
+ "nanoid",
  "serde",
  "serde_json",
+ "sha2",
  "telepair-agent",
  "telepair-core",
+ "tempfile",
  "tokio",
  "tracing",
  "uuid",
@@ -2327,6 +2331,7 @@ name = "telepair-core"
 version = "0.1.7"
 dependencies = [
  "argon2",
+ "bytes",
  "chrono",
  "hex",
  "nanoid",

--- a/crates/telepair-agent/Cargo.toml
+++ b/crates/telepair-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telepair-agent"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/telepair-cli/Cargo.toml
+++ b/crates/telepair-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telepair"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/telepair-cli/src/main.rs
+++ b/crates/telepair-cli/src/main.rs
@@ -13,6 +13,7 @@ use telepair_control::auth_service::{AuthService, SmtpConfig};
 use telepair_control::session_service::SessionService;
 use telepair_core::audit::{AuditEvent, AuditEventType, AuditFilter, AuditSink};
 use telepair_core::auth::TokenAuthProvider;
+use telepair_core::recording::RecordingConfig;
 use telepair_core::session::{CloseReason, User};
 use telepair_core::storage::{SqliteStorage, Storage};
 use telepair_gateway::state::AppState;
@@ -93,6 +94,21 @@ struct Cli {
     /// SMTP sender address, e.g. "Telepair <noreply@example.com>"
     #[arg(long, env = "TELEPAIR_SMTP_FROM")]
     smtp_from: Option<String>,
+
+    /// Enable session recording. When false (default), no sessions
+    /// are recorded regardless of per-session overrides.
+    #[arg(long, env = "TELEPAIR_RECORDING_ENABLED", default_value_t = false)]
+    recording_enabled: bool,
+
+    /// Recording retention in days. Recordings older than this are
+    /// candidates for automatic cleanup. 0 means permanent (no expiry).
+    #[arg(long, env = "TELEPAIR_RECORDING_TTL_DAYS", default_value_t = 30)]
+    recording_ttl_days: u32,
+
+    /// Directory to store recording files (.cast). Defaults to
+    /// `<data-dir>/recordings`.
+    #[arg(long, env = "TELEPAIR_RECORDING_DIR")]
+    recording_dir: Option<PathBuf>,
 
     /// Trust the `X-Forwarded-For` / `X-Real-IP` headers when keying
     /// the per-IP register rate limiter. Set this ONLY when telepair
@@ -758,8 +774,27 @@ async fn main() -> anyhow::Result<()> {
                     .ok_or_else(|| anyhow::anyhow!("--web-dir path is not valid UTF-8"))
             })
             .transpose()?;
-        let mut state = AppState::new(storage, engine, targets_path, smtp, data_dir.clone()).await;
+        let recording_config = RecordingConfig {
+            enabled: cli.recording_enabled,
+            ttl_days: cli.recording_ttl_days,
+            dir: cli
+                .recording_dir
+                .unwrap_or_else(|| data_dir.join("recordings")),
+        };
+        let mut state = AppState::new(
+            storage,
+            engine,
+            targets_path,
+            smtp,
+            data_dir.clone(),
+            recording_config,
+        )
+        .await;
         state.trust_forwarded_headers = cli.trust_forwarded_headers;
+        telepair_gateway::recording_cleaner::spawn_recording_cleaner(
+            state.storage.clone(),
+            state.recording.config().dir.clone(),
+        );
         let cors_mode = if cli.allow_any_origin {
             telepair_gateway::CorsMode::AllowAny
         } else {

--- a/crates/telepair-control/Cargo.toml
+++ b/crates/telepair-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telepair-control"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/telepair-control/Cargo.toml
+++ b/crates/telepair-control/Cargo.toml
@@ -16,6 +16,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 argon2 = { workspace = true }
 lettre = { workspace = true }
+sha2 = { workspace = true }
+nanoid = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+tempfile = { workspace = true }

--- a/crates/telepair-control/src/lib.rs
+++ b/crates/telepair-control/src/lib.rs
@@ -2,5 +2,6 @@
 
 pub mod auth_service;
 pub mod invite_service;
+pub mod recording_service;
 pub mod session_service;
 pub mod user_target_service;

--- a/crates/telepair-control/src/recording_service.rs
+++ b/crates/telepair-control/src/recording_service.rs
@@ -1,0 +1,525 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use telepair_core::auth::token_sha256;
+use telepair_core::error::{Error, Result};
+use telepair_core::recording::{AsciicastHeader, RecordingConfig, RecordingRow, RecordingShareRow};
+use telepair_core::storage::{SqliteStorage, Storage};
+
+/// Business logic layer for session recordings. Sits between the REST
+/// API (Task 8) and the storage + hub layers, centralizing conflict
+/// checks, TTL computation, file-path resolution, and share-token
+/// lifecycle.
+pub struct RecordingService {
+    storage: Arc<SqliteStorage>,
+    config: RecordingConfig,
+}
+
+impl RecordingService {
+    pub fn new(storage: Arc<SqliteStorage>, config: RecordingConfig) -> Self {
+        Self { storage, config }
+    }
+
+    pub fn config(&self) -> &RecordingConfig {
+        &self.config
+    }
+
+    /// Decide whether a session should be recorded. The server-wide
+    /// `config.enabled` flag is the master switch; a per-session
+    /// override (`Some(true)` / `Some(false)`) can opt individual
+    /// sessions in or out. `None` means "follow the global default".
+    pub fn should_record(&self, session_override: Option<bool>) -> bool {
+        match session_override {
+            Some(v) => v && self.config.enabled,
+            None => self.config.enabled,
+        }
+    }
+
+    /// Full filesystem path for a recording file.
+    /// Layout: `<dir>/<recording_id>.cast`
+    pub fn recording_file_path(&self, recording_id: &str) -> PathBuf {
+        self.config.dir.join(format!("{recording_id}.cast"))
+    }
+
+    /// Compute the `expires_at` timestamp based on the configured TTL.
+    /// Returns `None` when TTL is 0 (permanent).
+    pub fn compute_expires_at(&self) -> Option<String> {
+        if self.config.ttl_days == 0 {
+            return None;
+        }
+        let expires = Utc::now() + chrono::Duration::days(i64::from(self.config.ttl_days));
+        Some(expires.to_rfc3339())
+    }
+
+    /// Build an asciicast v2 header with telepair metadata.
+    pub fn build_header(
+        &self,
+        session_id: &str,
+        recording_id: &str,
+        width: u16,
+        height: u16,
+    ) -> AsciicastHeader {
+        let mut env = std::collections::HashMap::new();
+        env.insert("SHELL".to_string(), "/bin/bash".to_string());
+        env.insert("TERM".to_string(), "xterm-256color".to_string());
+
+        let telepair = serde_json::json!({
+            "session_id": session_id,
+            "recording_id": recording_id,
+        });
+
+        AsciicastHeader {
+            version: 2,
+            width,
+            height,
+            timestamp: Utc::now().timestamp(),
+            env,
+            telepair,
+        }
+    }
+
+    /// Create a new recording for a session. Enforces the "at most one
+    /// active recording per session" invariant by checking for an
+    /// existing `status = 'recording'` row first. Returns
+    /// `Error::Conflict` if one already exists.
+    pub async fn create_recording(
+        &self,
+        session_id: &str,
+        created_by: Uuid,
+        width: i64,
+        height: i64,
+    ) -> Result<RecordingRow> {
+        // Conflict check: one active recording per session.
+        if let Some(existing) = self.storage.find_active_recording(session_id).await? {
+            return Err(Error::Conflict(format!(
+                "session {session_id} already has an active recording: {}",
+                existing.id
+            )));
+        }
+
+        let recording_id = nanoid::nanoid!(21);
+        let file_path = format!("{recording_id}.cast");
+        let expires_at = self.compute_expires_at();
+
+        // Ensure the recordings directory exists.
+        std::fs::create_dir_all(&self.config.dir).map_err(|e| {
+            Error::Internal(format!(
+                "failed to create recordings dir {}: {e}",
+                self.config.dir.display()
+            ))
+        })?;
+
+        self.storage
+            .create_recording(
+                &recording_id,
+                session_id,
+                created_by,
+                width,
+                height,
+                &file_path,
+                expires_at.as_deref(),
+            )
+            .await
+    }
+
+    /// Look up a recording by id.
+    pub async fn get_recording(&self, id: &str) -> Result<Option<RecordingRow>> {
+        self.storage.get_recording(id).await
+    }
+
+    /// List all recordings created by a specific user.
+    pub async fn list_for_user(&self, user_id: Uuid) -> Result<Vec<RecordingRow>> {
+        self.storage.list_recordings_for_user(user_id).await
+    }
+
+    /// List every recording in the system (admin-only gate is the
+    /// caller's responsibility).
+    pub async fn list_all(&self) -> Result<Vec<RecordingRow>> {
+        self.storage.list_all_recordings().await
+    }
+
+    /// Hard-delete a recording row and its associated file on disk.
+    pub async fn delete_recording(&self, id: &str) -> Result<()> {
+        // Best-effort file removal. A missing file is not an error — the
+        // DB row is the authoritative "exists" record.
+        let path = self.recording_file_path(id);
+        let _ = std::fs::remove_file(&path);
+
+        self.storage.delete_recording(id).await
+    }
+
+    /// Clear `expires_at` so the recording never expires.
+    pub async fn set_permanent(&self, id: &str) -> Result<()> {
+        self.storage.set_recording_permanent(id).await
+    }
+
+    /// Set or update `expires_at` to a specific RFC3339 timestamp.
+    pub async fn set_expiry(&self, id: &str, expires_at: &str) -> Result<()> {
+        self.storage.set_recording_expiry(id, expires_at).await
+    }
+
+    /// Create a share token for a recording. Returns `(raw_token,
+    /// RecordingShareRow)` — the raw token is only visible at mint
+    /// time; the DB stores its SHA-256 digest.
+    pub async fn create_share(
+        &self,
+        recording_id: &str,
+        max_uses: i64,
+        expires_at: Option<&str>,
+    ) -> Result<(String, RecordingShareRow)> {
+        // Verify the recording exists.
+        self.storage
+            .get_recording(recording_id)
+            .await?
+            .ok_or_else(|| Error::InvalidInput(format!("recording not found: {recording_id}")))?;
+
+        let raw_token = nanoid::nanoid!(32);
+        let sha256_hex = token_sha256(&raw_token);
+
+        let row = self
+            .storage
+            .create_recording_share(recording_id, &sha256_hex, max_uses, expires_at)
+            .await?;
+
+        Ok((raw_token, row))
+    }
+
+    /// Atomically validate and consume a share token for the given
+    /// recording. Single SQL UPDATE that increments `used_count`
+    /// only if the token exists, belongs to `expected_recording_id`,
+    /// has not expired, and has remaining uses. Returns the
+    /// post-increment share row on success.
+    ///
+    /// Threading the recording id through the storage layer (instead
+    /// of validating it after the increment in the HTTP handler)
+    /// closes the previous TOCTOU window where two concurrent calls
+    /// could both pass an application-level `used_count < max_uses`
+    /// check, and prevents a holder of one recording's share from
+    /// burning the quota by hitting another recording's URL.
+    pub async fn validate_share_token(
+        &self,
+        raw_token: &str,
+        expected_recording_id: &str,
+    ) -> Result<RecordingShareRow> {
+        let sha256_hex = token_sha256(raw_token);
+        self.storage
+            .consume_recording_share(&sha256_hex, expected_recording_id)
+            .await?
+            .ok_or_else(|| Error::InvalidInput("invalid, expired, or exhausted share token".into()))
+    }
+
+    /// List all share tokens for a recording.
+    pub async fn list_shares(&self, recording_id: &str) -> Result<Vec<RecordingShareRow>> {
+        self.storage.list_recording_shares(recording_id).await
+    }
+
+    /// Hard-delete a share token by its SHA-256 digest. The admin UI
+    /// already has the digest from `list_shares`; the raw token is
+    /// only ever returned at mint time. Accepting the digest avoids
+    /// putting the raw secret in DELETE URLs (where it would land in
+    /// access logs and Referer headers) and prevents the previous
+    /// double-hash bug where the handler treated the URL parameter as
+    /// a raw token and re-hashed it before lookup.
+    pub async fn delete_share_by_sha256(&self, token_sha256: &str) -> Result<()> {
+        self.storage.delete_recording_share(token_sha256).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(dir: &std::path::Path) -> RecordingConfig {
+        RecordingConfig {
+            enabled: true,
+            ttl_days: 30,
+            dir: dir.to_path_buf(),
+        }
+    }
+
+    #[tokio::test]
+    async fn should_record_follows_global_default_when_no_override() {
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(
+            storage.clone(),
+            RecordingConfig {
+                enabled: true,
+                ttl_days: 30,
+                dir: PathBuf::from("/tmp"),
+            },
+        );
+        assert!(svc.should_record(None));
+
+        let svc2 = RecordingService::new(
+            storage,
+            RecordingConfig {
+                enabled: false,
+                ttl_days: 30,
+                dir: PathBuf::from("/tmp"),
+            },
+        );
+        assert!(!svc2.should_record(None));
+    }
+
+    #[tokio::test]
+    async fn should_record_override_true_requires_global_enabled() {
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(
+            storage,
+            RecordingConfig {
+                enabled: false,
+                ttl_days: 30,
+                dir: PathBuf::from("/tmp"),
+            },
+        );
+        // Override true but global disabled = no recording.
+        assert!(!svc.should_record(Some(true)));
+    }
+
+    #[tokio::test]
+    async fn should_record_override_false_disables_even_when_global_enabled() {
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(
+            storage,
+            RecordingConfig {
+                enabled: true,
+                ttl_days: 30,
+                dir: PathBuf::from("/tmp"),
+            },
+        );
+        assert!(!svc.should_record(Some(false)));
+    }
+
+    #[tokio::test]
+    async fn recording_file_path_builds_correct_path() {
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(
+            storage,
+            RecordingConfig {
+                enabled: true,
+                ttl_days: 30,
+                dir: PathBuf::from("/data/recordings"),
+            },
+        );
+        let path = svc.recording_file_path("abc123");
+        assert_eq!(path, PathBuf::from("/data/recordings/abc123.cast"));
+    }
+
+    #[tokio::test]
+    async fn compute_expires_at_returns_none_for_zero_ttl() {
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(
+            storage,
+            RecordingConfig {
+                enabled: true,
+                ttl_days: 0,
+                dir: PathBuf::from("/tmp"),
+            },
+        );
+        assert!(svc.compute_expires_at().is_none());
+    }
+
+    #[tokio::test]
+    async fn compute_expires_at_returns_some_for_positive_ttl() {
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(
+            storage,
+            RecordingConfig {
+                enabled: true,
+                ttl_days: 7,
+                dir: PathBuf::from("/tmp"),
+            },
+        );
+        let result = svc.compute_expires_at();
+        assert!(result.is_some());
+        let parsed = chrono::DateTime::parse_from_rfc3339(&result.unwrap());
+        assert!(parsed.is_ok());
+    }
+
+    #[tokio::test]
+    async fn build_header_populates_correctly() {
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(
+            storage,
+            RecordingConfig {
+                enabled: true,
+                ttl_days: 30,
+                dir: PathBuf::from("/tmp"),
+            },
+        );
+        let header = svc.build_header("sess-1", "rec-1", 80, 24);
+        assert_eq!(header.version, 2);
+        assert_eq!(header.width, 80);
+        assert_eq!(header.height, 24);
+        assert_eq!(header.telepair["session_id"], "sess-1");
+        assert_eq!(header.telepair["recording_id"], "rec-1");
+    }
+
+    #[test]
+    fn token_sha256_is_deterministic() {
+        let a = token_sha256("test-token");
+        let b = token_sha256("test-token");
+        assert_eq!(a, b);
+        assert_ne!(token_sha256("other"), a);
+    }
+
+    #[tokio::test]
+    async fn create_recording_enforces_single_active_per_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(storage.clone(), test_config(dir.path()));
+
+        // Seed a user and session.
+        let (user, _) = storage.create_user("tester", false).await.unwrap();
+        let session = storage
+            .create_session_with_owner(
+                user.id,
+                "local-shell",
+                telepair_core::session::InputMode::Serialized,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // First recording succeeds.
+        let rec = svc
+            .create_recording(&session.id, user.id, 80, 24)
+            .await
+            .unwrap();
+        assert_eq!(rec.session_id, session.id);
+
+        // Second recording for the same session is a conflict.
+        let err = svc
+            .create_recording(&session.id, user.id, 80, 24)
+            .await
+            .expect_err("duplicate active recording must conflict");
+        assert!(matches!(err, Error::Conflict(_)));
+    }
+
+    #[tokio::test]
+    async fn create_share_and_validate_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(storage.clone(), test_config(dir.path()));
+
+        let (user, _) = storage.create_user("tester", false).await.unwrap();
+        let session = storage
+            .create_session_with_owner(
+                user.id,
+                "local-shell",
+                telepair_core::session::InputMode::Serialized,
+                None,
+            )
+            .await
+            .unwrap();
+        let rec = svc
+            .create_recording(&session.id, user.id, 80, 24)
+            .await
+            .unwrap();
+
+        // Create a share with max_uses = 2.
+        let (raw, share) = svc.create_share(&rec.id, 2, None).await.unwrap();
+        assert_eq!(share.max_uses, 2);
+        assert_eq!(share.used_count, 0);
+
+        // First validation succeeds and increments usage.
+        let validated = svc.validate_share_token(&raw, &rec.id).await.unwrap();
+        assert_eq!(validated.recording_id, rec.id);
+        assert_eq!(validated.used_count, 1);
+
+        // Second validation also succeeds.
+        svc.validate_share_token(&raw, &rec.id).await.unwrap();
+
+        // Third validation should fail (max_uses exhausted).
+        let err = svc
+            .validate_share_token(&raw, &rec.id)
+            .await
+            .expect_err("exhausted share must fail");
+        assert!(matches!(err, Error::InvalidInput(_)));
+
+        // Wrong recording id must fail without consuming a use.
+        let err = svc
+            .validate_share_token(&raw, "some-other-recording")
+            .await
+            .expect_err("mismatched recording id must fail");
+        assert!(matches!(err, Error::InvalidInput(_)));
+    }
+
+    #[tokio::test]
+    async fn delete_share_removes_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(storage.clone(), test_config(dir.path()));
+
+        let (user, _) = storage.create_user("tester", false).await.unwrap();
+        let session = storage
+            .create_session_with_owner(
+                user.id,
+                "local-shell",
+                telepair_core::session::InputMode::Serialized,
+                None,
+            )
+            .await
+            .unwrap();
+        let rec = svc
+            .create_recording(&session.id, user.id, 80, 24)
+            .await
+            .unwrap();
+
+        let (raw, share) = svc.create_share(&rec.id, 0, None).await.unwrap();
+        svc.delete_share_by_sha256(&share.token_sha256)
+            .await
+            .unwrap();
+
+        // Token should no longer validate.
+        let err = svc
+            .validate_share_token(&raw, &rec.id)
+            .await
+            .expect_err("deleted share must fail");
+        assert!(matches!(err, Error::InvalidInput(_)));
+    }
+
+    #[tokio::test]
+    async fn list_shares_returns_all_for_recording() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(storage.clone(), test_config(dir.path()));
+
+        let (user, _) = storage.create_user("tester", false).await.unwrap();
+        let session = storage
+            .create_session_with_owner(
+                user.id,
+                "local-shell",
+                telepair_core::session::InputMode::Serialized,
+                None,
+            )
+            .await
+            .unwrap();
+        let rec = svc
+            .create_recording(&session.id, user.id, 80, 24)
+            .await
+            .unwrap();
+
+        svc.create_share(&rec.id, 5, None).await.unwrap();
+        svc.create_share(&rec.id, 10, None).await.unwrap();
+
+        let shares = svc.list_shares(&rec.id).await.unwrap();
+        assert_eq!(shares.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn create_share_for_nonexistent_recording_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(storage, test_config(dir.path()));
+
+        let err = svc
+            .create_share("nonexistent", 5, None)
+            .await
+            .expect_err("nonexistent recording must error");
+        assert!(matches!(err, Error::InvalidInput(_)));
+    }
+}

--- a/crates/telepair-control/src/recording_service.rs
+++ b/crates/telepair-control/src/recording_service.rs
@@ -142,11 +142,46 @@ impl RecordingService {
     }
 
     /// Hard-delete a recording row and its associated file on disk.
+    ///
+    /// Refuses to delete a recording that is still being captured
+    /// (`status == 'recording'`): the writer still holds the file
+    /// handle, `stop_recording` would race into a 404 because the
+    /// active row disappeared, and the hub's sender slot would stay
+    /// occupied until the session ends. Callers must stop the
+    /// recording first. Returns [`Error::Conflict`] (409) in that
+    /// case.
+    ///
+    /// File removal runs only after the status check passes. A
+    /// missing file is tolerated (already cleaned up by a previous
+    /// partial run or the TTL cleaner), but any other I/O failure
+    /// bubbles up so the DB row survives for a retry — deleting the
+    /// row with the file still on disk would create an orphan that
+    /// the TTL cleaner can never pick up again.
     pub async fn delete_recording(&self, id: &str) -> Result<()> {
-        // Best-effort file removal. A missing file is not an error — the
-        // DB row is the authoritative "exists" record.
+        let Some(row) = self.storage.get_recording(id).await? else {
+            // Row already gone — matches the idempotent semantics of
+            // the underlying storage DELETE. Skip the file removal
+            // so a typo-ed id doesn't nuke some other recording's
+            // file that shares a coincidental name.
+            return Ok(());
+        };
+        if row.status == "recording" {
+            return Err(Error::Conflict(format!(
+                "recording {id} is still being captured; stop it before deleting",
+            )));
+        }
+
         let path = self.recording_file_path(id);
-        let _ = std::fs::remove_file(&path);
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(Error::Internal(format!(
+                    "failed to remove recording file {}: {e}",
+                    path.display()
+                )));
+            }
+        }
 
         self.storage.delete_recording(id).await
     }
@@ -216,15 +251,25 @@ impl RecordingService {
         self.storage.list_recording_shares(recording_id).await
     }
 
-    /// Hard-delete a share token by its SHA-256 digest. The admin UI
-    /// already has the digest from `list_shares`; the raw token is
-    /// only ever returned at mint time. Accepting the digest avoids
-    /// putting the raw secret in DELETE URLs (where it would land in
-    /// access logs and Referer headers) and prevents the previous
-    /// double-hash bug where the handler treated the URL parameter as
-    /// a raw token and re-hashed it before lookup.
-    pub async fn delete_share_by_sha256(&self, token_sha256: &str) -> Result<()> {
-        self.storage.delete_recording_share(token_sha256).await
+    /// Hard-delete a share token by its SHA-256 digest, scoped to
+    /// `recording_id`. Returns `true` if a matching share was
+    /// actually deleted, `false` if none existed under this
+    /// recording. The scope is load-bearing: the share digest is not
+    /// a secret (it is the SHA-256 of a token that already appears
+    /// verbatim in the share link), so a delete-by-digest-only API
+    /// lets any owner revoke another owner's share by passing their
+    /// own `recording_id` on the URL. Binding the delete to
+    /// `(recording_id, token_sha256)` closes that hole; handlers then
+    /// map `false` to 404 so a mismatched revoke looks exactly like
+    /// a truly-unknown digest.
+    pub async fn delete_share_by_sha256(
+        &self,
+        recording_id: &str,
+        token_sha256: &str,
+    ) -> Result<bool> {
+        self.storage
+            .delete_recording_share(recording_id, token_sha256)
+            .await
     }
 }
 
@@ -470,9 +515,11 @@ mod tests {
             .unwrap();
 
         let (raw, share) = svc.create_share(&rec.id, 0, None).await.unwrap();
-        svc.delete_share_by_sha256(&share.token_sha256)
+        let deleted = svc
+            .delete_share_by_sha256(&rec.id, &share.token_sha256)
             .await
             .unwrap();
+        assert!(deleted, "well-scoped revoke must report deletion");
 
         // Token should no longer validate.
         let err = svc
@@ -480,6 +527,60 @@ mod tests {
             .await
             .expect_err("deleted share must fail");
         assert!(matches!(err, Error::InvalidInput(_)));
+    }
+
+    /// Service-level guard that the scoped revoke refuses a
+    /// mismatched `recording_id`. Paired with the storage-level
+    /// regression in `recording_storage_delete_share_is_scoped_to_recording_id`
+    /// so the contract is pinned at both layers — a future refactor
+    /// that shortcuts the scope check via the service (e.g. auto-
+    /// forwarding the URL digest to a new helper) still trips this
+    /// test.
+    #[tokio::test]
+    async fn delete_share_refuses_mismatched_recording_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(storage.clone(), test_config(dir.path()));
+
+        let (user, _) = storage.create_user("tester", false).await.unwrap();
+        let session = storage
+            .create_session_with_owner(
+                user.id,
+                "local-shell",
+                telepair_core::session::InputMode::Serialized,
+                None,
+            )
+            .await
+            .unwrap();
+        let rec_a = svc
+            .create_recording(&session.id, user.id, 80, 24)
+            .await
+            .unwrap();
+        // Second recording for the same session must NOT conflict with
+        // the first — complete the first so the "one active recording
+        // per session" invariant stays happy.
+        storage
+            .complete_recording(&rec_a.id, 1000, 1, 256)
+            .await
+            .unwrap();
+        let rec_b = svc
+            .create_recording(&session.id, user.id, 80, 24)
+            .await
+            .unwrap();
+
+        let (raw, share) = svc.create_share(&rec_a.id, 0, None).await.unwrap();
+
+        // Wrong recording id is a no-op.
+        let deleted = svc
+            .delete_share_by_sha256(&rec_b.id, &share.token_sha256)
+            .await
+            .unwrap();
+        assert!(!deleted, "revoke under wrong recording_id must not match");
+
+        // The share still validates against the right recording id.
+        svc.validate_share_token(&raw, &rec_a.id)
+            .await
+            .expect("share must survive a mismatched revoke");
     }
 
     #[tokio::test]
@@ -508,6 +609,126 @@ mod tests {
 
         let shares = svc.list_shares(&rec.id).await.unwrap();
         assert_eq!(shares.len(), 2);
+    }
+
+    /// Regression for "deleting an active recording wedges the
+    /// session." Before the fix, `delete_recording` removed the
+    /// file and the DB row even while a writer still held the
+    /// file handle — `stop_recording` then 404'd (no active row to
+    /// find), the hub's sender slot stayed occupied, and a fresh
+    /// `start_recording` would conflict until the session ended.
+    /// The service now returns `Conflict` (409) without touching
+    /// the file or the row, so the recording stays consistent and
+    /// the caller gets an explicit "stop it first" signal.
+    #[tokio::test]
+    async fn delete_recording_refuses_while_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let svc = RecordingService::new(storage.clone(), test_config(dir.path()));
+
+        let (user, _) = storage.create_user("tester", false).await.unwrap();
+        let session = storage
+            .create_session_with_owner(
+                user.id,
+                "local-shell",
+                telepair_core::session::InputMode::Serialized,
+                None,
+            )
+            .await
+            .unwrap();
+        let rec = svc
+            .create_recording(&session.id, user.id, 80, 24)
+            .await
+            .unwrap();
+        // Simulate a real writer's side-effect — a file on disk we
+        // must NOT delete while the recording is active, or the
+        // writer would be left with a dangling handle.
+        let path = svc.recording_file_path(&rec.id);
+        std::fs::write(&path, b"live capture in progress").unwrap();
+
+        let err = svc
+            .delete_recording(&rec.id)
+            .await
+            .expect_err("active recording must not be deletable");
+        assert!(matches!(err, Error::Conflict(_)));
+
+        // File must still exist — deleting it out from under the
+        // writer would corrupt the capture.
+        assert!(path.exists(), "file must survive a blocked delete attempt");
+        // Row must still exist.
+        assert!(
+            storage.get_recording(&rec.id).await.unwrap().is_some(),
+            "DB row must survive a blocked delete attempt"
+        );
+
+        // After completion, delete goes through.
+        storage
+            .complete_recording(&rec.id, 500, 3, 64)
+            .await
+            .unwrap();
+        svc.delete_recording(&rec.id).await.unwrap();
+        assert!(!path.exists());
+        assert!(storage.get_recording(&rec.id).await.unwrap().is_none());
+    }
+
+    /// When the file is present but `remove_file` fails for any
+    /// reason other than NotFound, the service must bail BEFORE
+    /// deleting the DB row. Leaving the row alive lets the TTL
+    /// cleaner (or a retry from the owner) come back and try
+    /// again — removing the row would strand the file on disk with
+    /// no authoritative record the cleaner can match against.
+    #[tokio::test]
+    async fn delete_recording_preserves_row_when_file_remove_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        // Point the service's recording dir at a path we'll swap
+        // into a non-writable state *without* actually touching
+        // filesystem permissions (permission-based tests are flaky
+        // across macOS/Linux and in CI containers): we simulate
+        // the IO failure by creating a *directory* where the
+        // `.cast` file should live. `std::fs::remove_file` on a
+        // directory returns Err on every platform.
+        let svc = RecordingService::new(storage.clone(), test_config(dir.path()));
+
+        let (user, _) = storage.create_user("tester", false).await.unwrap();
+        let session = storage
+            .create_session_with_owner(
+                user.id,
+                "local-shell",
+                telepair_core::session::InputMode::Serialized,
+                None,
+            )
+            .await
+            .unwrap();
+        let rec = svc
+            .create_recording(&session.id, user.id, 80, 24)
+            .await
+            .unwrap();
+        storage
+            .complete_recording(&rec.id, 500, 3, 64)
+            .await
+            .unwrap();
+
+        // Replace the would-be file with a non-empty directory so
+        // `remove_file` fails with something other than NotFound.
+        let path = svc.recording_file_path(&rec.id);
+        std::fs::create_dir(&path).unwrap();
+        std::fs::write(path.join("sentinel"), b"").unwrap();
+
+        let err = svc
+            .delete_recording(&rec.id)
+            .await
+            .expect_err("file remove failure must surface");
+        assert!(matches!(err, Error::Internal(_)));
+
+        assert!(
+            path.exists(),
+            "directory (standing in for the file) must survive the failed delete"
+        );
+        assert!(
+            storage.get_recording(&rec.id).await.unwrap().is_some(),
+            "DB row must not be removed when file removal failed"
+        );
     }
 
     #[tokio::test]

--- a/crates/telepair-core/Cargo.toml
+++ b/crates/telepair-core/Cargo.toml
@@ -19,7 +19,9 @@ hex = { workspace = true }
 argon2 = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
+bytes = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
+bytes = { workspace = true }

--- a/crates/telepair-core/Cargo.toml
+++ b/crates/telepair-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telepair-core"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/telepair-core/src/audit.rs
+++ b/crates/telepair-core/src/audit.rs
@@ -157,6 +157,13 @@ pub enum AuditEventType {
     /// the host operator, not an authenticated HTTP caller.
     #[serde(rename = "auth.admin_user_created")]
     AuthAdminUserCreated,
+    /// A recording started for a session. Detail: `{recording_id, session_id}`.
+    #[serde(rename = "recording.started")]
+    RecordingStarted,
+    /// A recording stopped (completed or aborted). Detail:
+    /// `{recording_id, session_id, duration_s}`.
+    #[serde(rename = "recording.stopped")]
+    RecordingStopped,
 }
 
 impl AuditEventType {
@@ -181,6 +188,8 @@ impl AuditEventType {
             Self::AuthPasswordChanged => "auth.password_changed",
             Self::ParticipantRoleChanged => "participant.role_changed",
             Self::AuthAdminUserCreated => "auth.admin_user_created",
+            Self::RecordingStarted => "recording.started",
+            Self::RecordingStopped => "recording.stopped",
         }
     }
 }
@@ -208,6 +217,8 @@ impl FromStr for AuditEventType {
             "auth.password_changed" => Ok(Self::AuthPasswordChanged),
             "participant.role_changed" => Ok(Self::ParticipantRoleChanged),
             "auth.admin_user_created" => Ok(Self::AuthAdminUserCreated),
+            "recording.started" => Ok(Self::RecordingStarted),
+            "recording.stopped" => Ok(Self::RecordingStopped),
             _ => Err(format!("unknown audit event type: {s}")),
         }
     }

--- a/crates/telepair-core/src/auth.rs
+++ b/crates/telepair-core/src/auth.rs
@@ -1,8 +1,19 @@
 use std::sync::Arc;
 
+use sha2::{Digest, Sha256};
+
 use crate::error::{Error, Result};
 use crate::session::User;
 use crate::storage::{SqliteStorage, Storage};
+
+/// SHA-256 hex digest of a raw token. The DB stores only this digest,
+/// so callers minting or looking up a token go through here — keeps
+/// the hashing convention (algorithm, encoding) in one place across
+/// invites, recording shares, and any future token-backed surface.
+pub fn token_sha256(raw: &str) -> String {
+    let hash = Sha256::digest(raw.as_bytes());
+    hex::encode(hash)
+}
 
 /// Max attempts when generating a unique guest name before giving up.
 /// `users.name` is UNIQUE; with 8 chars of nanoid entropy (~47 bits)

--- a/crates/telepair-core/src/lib.rs
+++ b/crates/telepair-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod auth;
 pub mod error;
 pub mod permission;
 pub mod protocol;
+pub mod recording;
 pub mod session;
 pub mod storage;
 pub mod target;

--- a/crates/telepair-core/src/protocol.rs
+++ b/crates/telepair-core/src/protocol.rs
@@ -133,6 +133,14 @@ pub enum EvictReason {
     TokenRotated,
 }
 
+/// Recording status embedded in `SessionState` so late joiners know
+/// immediately whether a recording is active when they connect.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RecordingStatusInfo {
+    pub recording_id: String,
+    pub started_at: String,
+}
+
 // --- Server -> Client ---
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -146,6 +154,9 @@ pub enum ServerMessage {
         /// dies with the session; see `session_hub::CHAT_HISTORY_CAP`.
         #[serde(default)]
         chat_history: Vec<ChatEntry>,
+        /// Present when a recording is active at join time.
+        #[serde(default)]
+        recording: Option<RecordingStatusInfo>,
     },
     PeerJoined {
         user_id: Uuid,
@@ -209,6 +220,14 @@ pub enum ServerMessage {
     Error {
         code: String,
         message: String,
+    },
+    /// Broadcast to all participants when a recording starts on this session.
+    RecordingStarted {
+        recording_id: String,
+    },
+    /// Broadcast to all participants when a recording stops on this session.
+    RecordingStopped {
+        recording_id: String,
     },
 }
 

--- a/crates/telepair-core/src/recording.rs
+++ b/crates/telepair-core/src/recording.rs
@@ -1,0 +1,160 @@
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ── Asciicast v2 format types ──────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AsciicastHeader {
+    pub version: u8,
+    pub width: u16,
+    pub height: u16,
+    pub timestamp: i64,
+    pub env: HashMap<String, String>,
+    pub telepair: serde_json::Value,
+}
+
+/// Events captured during recording.
+/// `Stop` is a control signal — not serialized to the .cast file.
+#[derive(Debug, Clone)]
+pub enum RecordingEvent {
+    Output(Bytes),
+    Resize {
+        cols: u16,
+        rows: u16,
+    },
+    ParticipantJoin {
+        user_id: String,
+        name: String,
+        role: String,
+    },
+    ParticipantLeave {
+        user_id: String,
+    },
+    Chat {
+        user_id: String,
+        name: String,
+        text: String,
+    },
+    Stop,
+}
+
+impl RecordingEvent {
+    /// Serialize to a single asciicast v2 NDJSON line.
+    pub fn to_asciicast_line(&self, elapsed_secs: f64) -> String {
+        match self {
+            Self::Output(data) => {
+                let s = String::from_utf8_lossy(data.as_ref());
+                let escaped = serde_json::to_string(s.as_ref()).unwrap_or_default();
+                format!("[{elapsed_secs:.6}, \"o\", {escaped}]")
+            }
+            Self::Resize { cols, rows } => {
+                format!("[{elapsed_secs:.6}, \"r\", \"{cols}x{rows}\"]")
+            }
+            Self::ParticipantJoin {
+                user_id,
+                name,
+                role,
+            } => {
+                let obj = serde_json::json!({
+                    "user_id": user_id, "name": name, "role": role
+                });
+                let serialized = serde_json::to_string(&obj).unwrap_or_default();
+                format!("[{elapsed_secs:.6}, \"j\", {serialized}]")
+            }
+            Self::ParticipantLeave { user_id } => {
+                let obj = serde_json::json!({ "user_id": user_id });
+                let serialized = serde_json::to_string(&obj).unwrap_or_default();
+                format!("[{elapsed_secs:.6}, \"l\", {serialized}]")
+            }
+            Self::Chat {
+                user_id,
+                name,
+                text,
+            } => {
+                let obj = serde_json::json!({
+                    "user_id": user_id, "name": name, "text": text
+                });
+                let serialized = serde_json::to_string(&obj).unwrap_or_default();
+                format!("[{elapsed_secs:.6}, \"c\", {serialized}]")
+            }
+            Self::Stop => unreachable!("Stop is a control signal, not serialized"),
+        }
+    }
+}
+
+// ── Database row types ─────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RecordingStatus {
+    Recording,
+    Completed,
+    Failed,
+}
+
+impl RecordingStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Recording => "recording",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "recording" => Some(Self::Recording),
+            "completed" => Some(Self::Completed),
+            "failed" => Some(Self::Failed),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordingRow {
+    pub id: String,
+    pub session_id: String,
+    pub status: String,
+    pub file_path: Option<String>,
+    pub file_size: i64,
+    pub duration_ms: Option<i64>,
+    pub width: i64,
+    pub height: i64,
+    pub event_count: i64,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    pub expires_at: Option<String>,
+    pub created_by: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordingShareRow {
+    pub token_sha256: String,
+    pub recording_id: String,
+    pub max_uses: i64,
+    pub used_count: i64,
+    pub expires_at: Option<String>,
+    pub created_at: String,
+}
+
+// ── Recording config ───────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct RecordingConfig {
+    pub enabled: bool,
+    pub ttl_days: u32,
+    pub dir: std::path::PathBuf,
+}
+
+impl Default for RecordingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            ttl_days: 30,
+            dir: std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default())
+                .join(".telepair")
+                .join("recordings"),
+        }
+    }
+}

--- a/crates/telepair-core/src/storage.rs
+++ b/crates/telepair-core/src/storage.rs
@@ -487,6 +487,14 @@ pub trait Storage: Send + Sync {
     /// List all share tokens for a recording, newest-first.
     async fn list_recording_shares(&self, recording_id: &str) -> Result<Vec<RecordingShareRow>>;
 
-    /// Hard-delete a share token row.
-    async fn delete_recording_share(&self, token_sha256: &str) -> Result<()>;
+    /// Hard-delete a share token row scoped to `recording_id`. The
+    /// URL path (not the digest alone) is the authoritative scope:
+    /// without the recording_id filter, any owner who happens to know
+    /// a share digest — which is trivially computable from the raw
+    /// token the share link already embeds — could revoke shares
+    /// belonging to other recordings by hitting the delete endpoint
+    /// with their own `recording_id` in the URL. Returns `true` if a
+    /// matching row was deleted, `false` otherwise; callers map the
+    /// `false` case to 404.
+    async fn delete_recording_share(&self, recording_id: &str, token_sha256: &str) -> Result<bool>;
 }

--- a/crates/telepair-core/src/storage.rs
+++ b/crates/telepair-core/src/storage.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 use crate::audit::{AuditEvent, AuditFilter};
 use crate::error::Result;
 use crate::permission::Role;
+use crate::recording::{RecordingRow, RecordingShareRow};
 use crate::session::{
     CloseReason, CreateUserTargetParams, InputMode, InviteToken, LoginFailureOutcome, Participant,
     PendingVerifyResult, RedeemIdentity, RedeemOutcome, Session, SessionListFilter, User,
@@ -381,4 +382,111 @@ pub trait Storage: Send + Sync {
     /// Query `audit_events` with the given filter. Rows are sorted
     /// newest-first. An unset `filter.limit` falls back to `100`.
     async fn list_audit_events(&self, filter: &AuditFilter) -> Result<Vec<AuditEvent>>;
+
+    // ── Recordings ────────────────────────────────────────────────────
+
+    /// Create a new recording row in `recording` status. The caller
+    /// supplies `id` so that the recording id, the on-disk filename,
+    /// and the DB primary key are all derived from a single source —
+    /// preventing the cleaner / downloader from looking up a file
+    /// under one id while the row was inserted under another.
+    /// `expires_at` is an optional RFC3339 string; `None` means the
+    /// recording never expires (permanent).
+    #[allow(clippy::too_many_arguments)] // Atomic insert, no natural sub-grouping.
+    async fn create_recording(
+        &self,
+        id: &str,
+        session_id: &str,
+        created_by: Uuid,
+        width: i64,
+        height: i64,
+        file_path: &str,
+        expires_at: Option<&str>,
+    ) -> Result<RecordingRow>;
+
+    /// Look up a recording by id. Returns `Ok(None)` on miss.
+    async fn get_recording(&self, id: &str) -> Result<Option<RecordingRow>>;
+
+    /// Transition a recording to `completed` status with final
+    /// duration, event count, and file size.
+    async fn complete_recording(
+        &self,
+        id: &str,
+        duration_ms: i64,
+        event_count: i64,
+        file_size: i64,
+    ) -> Result<()>;
+
+    /// Transition a recording to `failed` status.
+    async fn fail_recording(&self, id: &str) -> Result<()>;
+
+    /// Find the active (`status = 'recording'`) recording for a
+    /// session, if any. At most one recording per session can be
+    /// active at a time — the caller is responsible for enforcing
+    /// this invariant at creation time.
+    async fn find_active_recording(&self, session_id: &str) -> Result<Option<RecordingRow>>;
+
+    /// List all recordings created by a specific user, newest-first.
+    async fn list_recordings_for_user(&self, user_id: Uuid) -> Result<Vec<RecordingRow>>;
+
+    /// List every recording in the system, newest-first. Admin-only
+    /// gate is the caller's responsibility.
+    async fn list_all_recordings(&self) -> Result<Vec<RecordingRow>>;
+
+    /// List recordings whose `expires_at` has passed (< now), up to
+    /// `limit` rows. Used by the TTL cleaner to find candidates for
+    /// deletion.
+    async fn list_expired_recordings(&self, limit: i64) -> Result<Vec<RecordingRow>>;
+
+    /// Hard-delete a recording row. Cascade deletes will remove any
+    /// associated `recording_shares` rows.
+    async fn delete_recording(&self, id: &str) -> Result<()>;
+
+    /// Clear `expires_at` so the recording never expires.
+    async fn set_recording_permanent(&self, id: &str) -> Result<()>;
+
+    /// Set or update `expires_at` to the given RFC3339 timestamp.
+    async fn set_recording_expiry(&self, id: &str, expires_at: &str) -> Result<()>;
+
+    // ── Recording shares ──────────────────────────────────────────────
+
+    /// Create a share token row for a recording. `token_sha256` is the
+    /// hex-encoded SHA-256 of the raw token (the raw token is only
+    /// visible at mint time). `max_uses` of 0 means unlimited.
+    async fn create_recording_share(
+        &self,
+        recording_id: &str,
+        token_sha256: &str,
+        max_uses: i64,
+        expires_at: Option<&str>,
+    ) -> Result<RecordingShareRow>;
+
+    /// Atomically validate and consume a share token. Single SQL
+    /// statement that increments `used_count` only when ALL of the
+    /// following hold:
+    /// - the token row exists,
+    /// - it belongs to `expected_recording_id`,
+    /// - it has not expired (`expires_at IS NULL OR > now`),
+    /// - it has remaining uses (`max_uses = 0 OR used_count < max_uses`).
+    ///
+    /// Returns the post-increment row on success, `None` otherwise.
+    /// Doing this in one statement closes two earlier holes:
+    /// 1. TOCTOU race where two concurrent requests both pass an
+    ///    application-level `used_count < max_uses` check before
+    ///    either UPDATE landed and exhausted the limit;
+    /// 2. caller incrementing the counter before validating that the
+    ///    token belonged to the requested recording — letting any
+    ///    holder of a share burn another recording's quota with a
+    ///    bogus URL.
+    async fn consume_recording_share(
+        &self,
+        token_sha256: &str,
+        expected_recording_id: &str,
+    ) -> Result<Option<RecordingShareRow>>;
+
+    /// List all share tokens for a recording, newest-first.
+    async fn list_recording_shares(&self, recording_id: &str) -> Result<Vec<RecordingShareRow>>;
+
+    /// Hard-delete a share token row.
+    async fn delete_recording_share(&self, token_sha256: &str) -> Result<()>;
 }

--- a/crates/telepair-core/src/storage/sqlite.rs
+++ b/crates/telepair-core/src/storage/sqlite.rs
@@ -2,14 +2,15 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
-use sha2::{Digest, Sha256};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteRow};
 use sqlx::{Pool, Row, Sqlite, SqlitePool};
 use uuid::Uuid;
 
 use crate::audit::{AuditEvent, AuditEventType, AuditFilter};
+use crate::auth::token_sha256;
 use crate::error::{Error, Result};
 use crate::permission::Role;
+use crate::recording::{RecordingRow, RecordingShareRow, RecordingStatus};
 use crate::session::{
     ApprovalState, CloseReason, CreateUserTargetParams, InputMode, InviteToken,
     LoginFailureOutcome, Participant, PendingVerifyResult, RedeemIdentity, RedeemOutcome, Session,
@@ -55,6 +56,10 @@ impl SqliteStorage {
         // `CREATE TABLE/INDEX IF NOT EXISTS` so re-running it against
         // a populated DB is a no-op.
         sqlx::raw_sql(include_str!("../../../../migrations/001_initial.sql"))
+            .execute(&self.pool)
+            .await?;
+
+        sqlx::raw_sql(include_str!("../../../../migrations/002_recordings.sql"))
             .execute(&self.pool)
             .await?;
 
@@ -460,6 +465,35 @@ fn row_to_user_target(r: &SqliteRow) -> Result<UserTarget> {
     })
 }
 
+fn row_to_recording(r: &SqliteRow) -> RecordingRow {
+    RecordingRow {
+        id: r.get("id"),
+        session_id: r.get("session_id"),
+        status: r.get("status"),
+        file_path: r.get("file_path"),
+        file_size: r.get("file_size"),
+        duration_ms: r.get("duration_ms"),
+        width: r.get("width"),
+        height: r.get("height"),
+        event_count: r.get("event_count"),
+        started_at: r.get("started_at"),
+        completed_at: r.get("completed_at"),
+        expires_at: r.get("expires_at"),
+        created_by: r.get("created_by"),
+    }
+}
+
+fn row_to_recording_share(r: &SqliteRow) -> RecordingShareRow {
+    RecordingShareRow {
+        token_sha256: r.get("token_sha256"),
+        recording_id: r.get("recording_id"),
+        max_uses: r.get("max_uses"),
+        used_count: r.get("used_count"),
+        expires_at: r.get("expires_at"),
+        created_at: r.get("created_at"),
+    }
+}
+
 fn row_to_audit_event(r: &SqliteRow) -> Result<AuditEvent> {
     // `detail` is stored as JSON text and round-trips through
     // `serde_json`. SQL NULL maps back to `Value::Null` — the
@@ -489,12 +523,6 @@ fn row_to_audit_event(r: &SqliteRow) -> Result<AuditEvent> {
         session_id: r.get("session_id"),
         detail,
     })
-}
-
-/// Compute SHA-256 hex digest of a raw token for O(1) indexed lookup.
-fn token_sha256(raw: &str) -> String {
-    let hash = Sha256::digest(raw.as_bytes());
-    hex::encode(hash)
 }
 
 /// Generate a new token, returning (raw, sha256_hex). The sha256 digest
@@ -2138,6 +2166,258 @@ impl Storage for SqliteStorage {
         .fetch_optional(&self.pool)
         .await?;
         row.map(|r| row_to_user_target(&r)).transpose()
+    }
+
+    // ── Recordings ────────────────────────────────────────────────────
+
+    async fn create_recording(
+        &self,
+        id: &str,
+        session_id: &str,
+        created_by: Uuid,
+        width: i64,
+        height: i64,
+        file_path: &str,
+        expires_at: Option<&str>,
+    ) -> Result<RecordingRow> {
+        let now_str = now_rfc3339();
+
+        sqlx::query(
+            "INSERT INTO recordings \
+               (id, session_id, status, file_path, file_size, width, height, \
+                event_count, started_at, expires_at, created_by) \
+             VALUES (?, ?, ?, ?, 0, ?, ?, 0, ?, ?, ?)",
+        )
+        .bind(id)
+        .bind(session_id)
+        .bind(RecordingStatus::Recording.as_str())
+        .bind(file_path)
+        .bind(width)
+        .bind(height)
+        .bind(&now_str)
+        .bind(expires_at)
+        .bind(created_by.to_string())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(RecordingRow {
+            id: id.to_string(),
+            session_id: session_id.to_string(),
+            status: RecordingStatus::Recording.as_str().to_string(),
+            file_path: Some(file_path.to_string()),
+            file_size: 0,
+            duration_ms: None,
+            width,
+            height,
+            event_count: 0,
+            started_at: now_str,
+            completed_at: None,
+            expires_at: expires_at.map(|s| s.to_string()),
+            created_by: created_by.to_string(),
+        })
+    }
+
+    async fn get_recording(&self, id: &str) -> Result<Option<RecordingRow>> {
+        let row = sqlx::query("SELECT * FROM recordings WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(|r| row_to_recording(&r)))
+    }
+
+    async fn complete_recording(
+        &self,
+        id: &str,
+        duration_ms: i64,
+        event_count: i64,
+        file_size: i64,
+    ) -> Result<()> {
+        let now_str = now_rfc3339();
+        let result = sqlx::query(
+            "UPDATE recordings \
+             SET status = ?, duration_ms = ?, event_count = ?, \
+                 file_size = ?, completed_at = ? \
+             WHERE id = ?",
+        )
+        .bind(RecordingStatus::Completed.as_str())
+        .bind(duration_ms)
+        .bind(event_count)
+        .bind(file_size)
+        .bind(&now_str)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            return Err(Error::InvalidInput(format!("recording {id} not found")));
+        }
+        Ok(())
+    }
+
+    async fn fail_recording(&self, id: &str) -> Result<()> {
+        let now_str = now_rfc3339();
+        let result = sqlx::query("UPDATE recordings SET status = ?, completed_at = ? WHERE id = ?")
+            .bind(RecordingStatus::Failed.as_str())
+            .bind(&now_str)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        if result.rows_affected() == 0 {
+            return Err(Error::InvalidInput(format!("recording {id} not found")));
+        }
+        Ok(())
+    }
+
+    async fn find_active_recording(&self, session_id: &str) -> Result<Option<RecordingRow>> {
+        let row =
+            sqlx::query("SELECT * FROM recordings WHERE session_id = ? AND status = ? LIMIT 1")
+                .bind(session_id)
+                .bind(RecordingStatus::Recording.as_str())
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|r| row_to_recording(&r)))
+    }
+
+    async fn list_recordings_for_user(&self, user_id: Uuid) -> Result<Vec<RecordingRow>> {
+        let rows =
+            sqlx::query("SELECT * FROM recordings WHERE created_by = ? ORDER BY started_at DESC")
+                .bind(user_id.to_string())
+                .fetch_all(&self.pool)
+                .await?;
+        Ok(rows.iter().map(row_to_recording).collect())
+    }
+
+    async fn list_all_recordings(&self) -> Result<Vec<RecordingRow>> {
+        let rows = sqlx::query("SELECT * FROM recordings ORDER BY started_at DESC")
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.iter().map(row_to_recording).collect())
+    }
+
+    async fn list_expired_recordings(&self, limit: i64) -> Result<Vec<RecordingRow>> {
+        let now_str = now_rfc3339();
+        let rows = sqlx::query(
+            "SELECT * FROM recordings \
+             WHERE expires_at IS NOT NULL AND expires_at < ? \
+             ORDER BY expires_at ASC LIMIT ?",
+        )
+        .bind(&now_str)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_recording).collect())
+    }
+
+    async fn delete_recording(&self, id: &str) -> Result<()> {
+        sqlx::query("DELETE FROM recordings WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn set_recording_permanent(&self, id: &str) -> Result<()> {
+        let result = sqlx::query("UPDATE recordings SET expires_at = NULL WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        if result.rows_affected() == 0 {
+            return Err(Error::InvalidInput(format!("recording {id} not found")));
+        }
+        Ok(())
+    }
+
+    async fn set_recording_expiry(&self, id: &str, expires_at: &str) -> Result<()> {
+        let result = sqlx::query("UPDATE recordings SET expires_at = ? WHERE id = ?")
+            .bind(expires_at)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        if result.rows_affected() == 0 {
+            return Err(Error::InvalidInput(format!("recording {id} not found")));
+        }
+        Ok(())
+    }
+
+    // ── Recording shares ──────────────────────────────────────────────
+
+    async fn create_recording_share(
+        &self,
+        recording_id: &str,
+        token_sha256: &str,
+        max_uses: i64,
+        expires_at: Option<&str>,
+    ) -> Result<RecordingShareRow> {
+        let now_str = now_rfc3339();
+
+        sqlx::query(
+            "INSERT INTO recording_shares \
+               (token_sha256, recording_id, max_uses, used_count, expires_at, created_at) \
+             VALUES (?, ?, ?, 0, ?, ?)",
+        )
+        .bind(token_sha256)
+        .bind(recording_id)
+        .bind(max_uses)
+        .bind(expires_at)
+        .bind(&now_str)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(RecordingShareRow {
+            token_sha256: token_sha256.to_string(),
+            recording_id: recording_id.to_string(),
+            max_uses,
+            used_count: 0,
+            expires_at: expires_at.map(|s| s.to_string()),
+            created_at: now_str,
+        })
+    }
+
+    async fn consume_recording_share(
+        &self,
+        token_sha256: &str,
+        expected_recording_id: &str,
+    ) -> Result<Option<RecordingShareRow>> {
+        // Single statement: validation + increment + RETURNING in one
+        // shot. SQLite serialises writes per connection so this is
+        // atomic; sqlx ≥ 0.7 + SQLite ≥ 3.35 supports RETURNING.
+        // The `expires_at` comparison uses RFC3339 strings, which
+        // sort lexicographically the same as the underlying instants
+        // (UTC, fixed offset) — matching how `list_expired_recordings`
+        // already orders rows.
+        let row = sqlx::query(
+            "UPDATE recording_shares \
+             SET used_count = used_count + 1 \
+             WHERE token_sha256 = ? \
+               AND recording_id = ? \
+               AND (max_uses = 0 OR used_count < max_uses) \
+               AND (expires_at IS NULL OR expires_at > ?) \
+             RETURNING *",
+        )
+        .bind(token_sha256)
+        .bind(expected_recording_id)
+        .bind(now_rfc3339())
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| row_to_recording_share(&r)))
+    }
+
+    async fn list_recording_shares(&self, recording_id: &str) -> Result<Vec<RecordingShareRow>> {
+        let rows = sqlx::query(
+            "SELECT * FROM recording_shares \
+             WHERE recording_id = ? ORDER BY created_at DESC",
+        )
+        .bind(recording_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(row_to_recording_share).collect())
+    }
+
+    async fn delete_recording_share(&self, token_sha256: &str) -> Result<()> {
+        sqlx::query("DELETE FROM recording_shares WHERE token_sha256 = ?")
+            .bind(token_sha256)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
     }
 }
 

--- a/crates/telepair-core/src/storage/sqlite.rs
+++ b/crates/telepair-core/src/storage/sqlite.rs
@@ -2295,9 +2295,18 @@ impl Storage for SqliteStorage {
 
     async fn list_expired_recordings(&self, limit: i64) -> Result<Vec<RecordingRow>> {
         let now_str = now_rfc3339();
+        // Excluding `status = 'recording'` is defense-in-depth: a
+        // fresh recording's `expires_at` is always `now + ttl_days`,
+        // so a still-active row shouldn't appear in this query under
+        // normal operation. The filter protects against the edge
+        // case where a wall-clock jump or a bad `expires_at` write
+        // would otherwise hand the TTL cleaner an active row and it
+        // would silently delete the writer's file out from under it.
         let rows = sqlx::query(
             "SELECT * FROM recordings \
-             WHERE expires_at IS NOT NULL AND expires_at < ? \
+             WHERE expires_at IS NOT NULL \
+               AND expires_at < ? \
+               AND status != 'recording' \
              ORDER BY expires_at ASC LIMIT ?",
         )
         .bind(&now_str)
@@ -2412,12 +2421,14 @@ impl Storage for SqliteStorage {
         Ok(rows.iter().map(row_to_recording_share).collect())
     }
 
-    async fn delete_recording_share(&self, token_sha256: &str) -> Result<()> {
-        sqlx::query("DELETE FROM recording_shares WHERE token_sha256 = ?")
-            .bind(token_sha256)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
+    async fn delete_recording_share(&self, recording_id: &str, token_sha256: &str) -> Result<bool> {
+        let result =
+            sqlx::query("DELETE FROM recording_shares WHERE recording_id = ? AND token_sha256 = ?")
+                .bind(recording_id)
+                .bind(token_sha256)
+                .execute(&self.pool)
+                .await?;
+        Ok(result.rows_affected() > 0)
     }
 }
 

--- a/crates/telepair-core/tests/recording_storage_test.rs
+++ b/crates/telepair-core/tests/recording_storage_test.rs
@@ -1,0 +1,399 @@
+use telepair_core::recording::RecordingStatus;
+use telepair_core::session::InputMode;
+use telepair_core::storage::{SqliteStorage, Storage};
+
+async fn setup() -> SqliteStorage {
+    SqliteStorage::new_memory().await.unwrap()
+}
+
+/// Create a user + session, returning (user_id, session_id).
+async fn seed(store: &SqliteStorage) -> (uuid::Uuid, String) {
+    let (user, _) = store.create_user("recorder", false).await.unwrap();
+    let session = store
+        .create_session_with_owner(user.id, "default", InputMode::Serialized, None)
+        .await
+        .unwrap();
+    (user.id, session.id)
+}
+
+#[tokio::test]
+async fn recording_storage_create_and_get_recording() {
+    let store = setup().await;
+    let (user_id, session_id) = seed(&store).await;
+
+    let rec = store
+        .create_recording(
+            "rec_test",
+            &session_id,
+            user_id,
+            120,
+            40,
+            "/tmp/test.cast",
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(rec.session_id, session_id);
+    assert_eq!(rec.status, "recording");
+    assert_eq!(rec.width, 120);
+    assert_eq!(rec.height, 40);
+    assert_eq!(rec.file_path, Some("/tmp/test.cast".to_string()));
+    assert_eq!(rec.created_by, user_id.to_string());
+    assert!(rec.expires_at.is_none());
+
+    let fetched = store.get_recording(&rec.id).await.unwrap().unwrap();
+    assert_eq!(fetched.id, rec.id);
+    assert_eq!(fetched.session_id, session_id);
+    assert_eq!(fetched.width, 120);
+    assert_eq!(fetched.height, 40);
+}
+
+#[tokio::test]
+async fn recording_storage_complete_recording() {
+    let store = setup().await;
+    let (user_id, session_id) = seed(&store).await;
+
+    let rec = store
+        .create_recording("rec_c", &session_id, user_id, 80, 24, "/tmp/c.cast", None)
+        .await
+        .unwrap();
+
+    store
+        .complete_recording(&rec.id, 5000, 42, 8192)
+        .await
+        .unwrap();
+
+    let fetched = store.get_recording(&rec.id).await.unwrap().unwrap();
+    assert_eq!(fetched.status, RecordingStatus::Completed.as_str());
+    assert_eq!(fetched.duration_ms, Some(5000));
+    assert_eq!(fetched.event_count, 42);
+    assert_eq!(fetched.file_size, 8192);
+    assert!(fetched.completed_at.is_some());
+}
+
+#[tokio::test]
+async fn recording_storage_fail_recording() {
+    let store = setup().await;
+    let (user_id, session_id) = seed(&store).await;
+
+    let rec = store
+        .create_recording("rec_f", &session_id, user_id, 80, 24, "/tmp/f.cast", None)
+        .await
+        .unwrap();
+
+    store.fail_recording(&rec.id).await.unwrap();
+
+    let fetched = store.get_recording(&rec.id).await.unwrap().unwrap();
+    assert_eq!(fetched.status, RecordingStatus::Failed.as_str());
+    assert!(fetched.completed_at.is_some());
+}
+
+#[tokio::test]
+async fn recording_storage_list_recordings_for_user() {
+    let store = setup().await;
+    let (user_id, session_id) = seed(&store).await;
+
+    // Create a second user with their own recording
+    let (other, _) = store.create_user("other", false).await.unwrap();
+    let other_session = store
+        .create_session_with_owner(other.id, "default", InputMode::Serialized, None)
+        .await
+        .unwrap();
+
+    store
+        .create_recording("rec_a", &session_id, user_id, 80, 24, "/tmp/a.cast", None)
+        .await
+        .unwrap();
+    store
+        .create_recording("rec_b", &session_id, user_id, 80, 24, "/tmp/b.cast", None)
+        .await
+        .unwrap();
+    store
+        .create_recording(
+            "rec_c2",
+            &other_session.id,
+            other.id,
+            80,
+            24,
+            "/tmp/c.cast",
+            None,
+        )
+        .await
+        .unwrap();
+
+    let mine = store.list_recordings_for_user(user_id).await.unwrap();
+    assert_eq!(mine.len(), 2);
+    for r in &mine {
+        assert_eq!(r.created_by, user_id.to_string());
+    }
+
+    let theirs = store.list_recordings_for_user(other.id).await.unwrap();
+    assert_eq!(theirs.len(), 1);
+}
+
+#[tokio::test]
+async fn recording_storage_find_active_recording_for_session() {
+    let store = setup().await;
+    let (user_id, session_id) = seed(&store).await;
+
+    // No active recording yet
+    let none = store.find_active_recording(&session_id).await.unwrap();
+    assert!(none.is_none());
+
+    // Create one
+    let rec = store
+        .create_recording(
+            "rec_active",
+            &session_id,
+            user_id,
+            80,
+            24,
+            "/tmp/active.cast",
+            None,
+        )
+        .await
+        .unwrap();
+
+    let active = store
+        .find_active_recording(&session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(active.id, rec.id);
+
+    // Complete it — should no longer be found
+    store
+        .complete_recording(&rec.id, 1000, 10, 512)
+        .await
+        .unwrap();
+    let gone = store.find_active_recording(&session_id).await.unwrap();
+    assert!(gone.is_none());
+}
+
+#[tokio::test]
+async fn recording_storage_share_crud() {
+    let store = setup().await;
+    let (user_id, session_id) = seed(&store).await;
+
+    let rec = store
+        .create_recording(
+            "rec_share",
+            &session_id,
+            user_id,
+            80,
+            24,
+            "/tmp/share.cast",
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Create a share
+    let share = store
+        .create_recording_share(&rec.id, "hash_abc", 5, None)
+        .await
+        .unwrap();
+    assert_eq!(share.recording_id, rec.id);
+    assert_eq!(share.max_uses, 5);
+    assert_eq!(share.used_count, 0);
+
+    // List shares
+    let shares = store.list_recording_shares(&rec.id).await.unwrap();
+    assert_eq!(shares.len(), 1);
+    assert_eq!(shares[0].token_sha256, "hash_abc");
+
+    // Consume increments and returns the updated row.
+    let consumed = store
+        .consume_recording_share("hash_abc", &rec.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(consumed.recording_id, rec.id);
+    assert_eq!(consumed.used_count, 1);
+
+    // Wrong recording id returns None and does not increment.
+    let mismatch = store
+        .consume_recording_share("hash_abc", "other-rec")
+        .await
+        .unwrap();
+    assert!(mismatch.is_none());
+
+    // Delete
+    store.delete_recording_share("hash_abc").await.unwrap();
+    let gone = store
+        .consume_recording_share("hash_abc", &rec.id)
+        .await
+        .unwrap();
+    assert!(gone.is_none());
+}
+
+#[tokio::test]
+async fn recording_storage_consume_share_blocks_when_exhausted_or_expired() {
+    let store = setup().await;
+    let (user_id, session_id) = seed(&store).await;
+
+    let rec = store
+        .create_recording(
+            "rec_consume",
+            &session_id,
+            user_id,
+            80,
+            24,
+            "/tmp/consume.cast",
+            None,
+        )
+        .await
+        .unwrap();
+
+    // max_uses = 1 share — second consume must miss.
+    store
+        .create_recording_share(&rec.id, "hash_one_use", 1, None)
+        .await
+        .unwrap();
+    let first = store
+        .consume_recording_share("hash_one_use", &rec.id)
+        .await
+        .unwrap();
+    assert!(first.is_some(), "first use must succeed");
+    let second = store
+        .consume_recording_share("hash_one_use", &rec.id)
+        .await
+        .unwrap();
+    assert!(second.is_none(), "second use must be blocked");
+
+    // Expired share — consume must miss without incrementing.
+    let past = "2020-01-01T00:00:00+00:00";
+    store
+        .create_recording_share(&rec.id, "hash_expired", 0, Some(past))
+        .await
+        .unwrap();
+    let expired = store
+        .consume_recording_share("hash_expired", &rec.id)
+        .await
+        .unwrap();
+    assert!(expired.is_none(), "expired share must be blocked");
+}
+
+#[tokio::test]
+async fn recording_storage_list_expired_recordings() {
+    let store = setup().await;
+    let (user_id, session_id) = seed(&store).await;
+
+    // Create one with an already-past expiry
+    let past = "2020-01-01T00:00:00+00:00";
+    store
+        .create_recording(
+            "rec_old",
+            &session_id,
+            user_id,
+            80,
+            24,
+            "/tmp/old.cast",
+            Some(past),
+        )
+        .await
+        .unwrap();
+
+    // Create one with no expiry (permanent)
+    store
+        .create_recording(
+            "rec_perm_e",
+            &session_id,
+            user_id,
+            80,
+            24,
+            "/tmp/perm.cast",
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Create one with future expiry
+    let future = "2099-01-01T00:00:00+00:00";
+    store
+        .create_recording(
+            "rec_future",
+            &session_id,
+            user_id,
+            80,
+            24,
+            "/tmp/future.cast",
+            Some(future),
+        )
+        .await
+        .unwrap();
+
+    let expired = store.list_expired_recordings(10).await.unwrap();
+    assert_eq!(expired.len(), 1);
+    assert_eq!(expired[0].file_path, Some("/tmp/old.cast".to_string()));
+}
+
+#[tokio::test]
+async fn recording_storage_delete_recording() {
+    let store = setup().await;
+    let (user_id, session_id) = seed(&store).await;
+
+    let rec = store
+        .create_recording(
+            "rec_del",
+            &session_id,
+            user_id,
+            80,
+            24,
+            "/tmp/del.cast",
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Add a share to verify cascade
+    store
+        .create_recording_share(&rec.id, "hash_del", 3, None)
+        .await
+        .unwrap();
+
+    store.delete_recording(&rec.id).await.unwrap();
+
+    let gone = store.get_recording(&rec.id).await.unwrap();
+    assert!(gone.is_none());
+
+    // Share should also be gone (cascade)
+    let shares = store.list_recording_shares(&rec.id).await.unwrap();
+    assert!(shares.is_empty());
+}
+
+#[tokio::test]
+async fn recording_storage_set_recording_permanent() {
+    let store = setup().await;
+    let (user_id, session_id) = seed(&store).await;
+
+    let expiry = "2099-01-01T00:00:00+00:00";
+    let rec = store
+        .create_recording(
+            "rec_perm",
+            &session_id,
+            user_id,
+            80,
+            24,
+            "/tmp/perm.cast",
+            Some(expiry),
+        )
+        .await
+        .unwrap();
+    assert!(rec.expires_at.is_some());
+
+    // Make permanent (clear expires_at)
+    store.set_recording_permanent(&rec.id).await.unwrap();
+    let fetched = store.get_recording(&rec.id).await.unwrap().unwrap();
+    assert!(fetched.expires_at.is_none());
+
+    // Restore an expiry
+    let new_expiry = "2098-06-15T00:00:00+00:00";
+    store
+        .set_recording_expiry(&rec.id, new_expiry)
+        .await
+        .unwrap();
+    let fetched2 = store.get_recording(&rec.id).await.unwrap().unwrap();
+    assert_eq!(fetched2.expires_at, Some(new_expiry.to_string()));
+}

--- a/crates/telepair-core/tests/recording_storage_test.rs
+++ b/crates/telepair-core/tests/recording_storage_test.rs
@@ -220,9 +220,90 @@ async fn recording_storage_share_crud() {
     assert!(mismatch.is_none());
 
     // Delete
-    store.delete_recording_share("hash_abc").await.unwrap();
+    let deleted = store
+        .delete_recording_share(&rec.id, "hash_abc")
+        .await
+        .unwrap();
+    assert!(deleted, "delete must report a row was removed");
     let gone = store
         .consume_recording_share("hash_abc", &rec.id)
+        .await
+        .unwrap();
+    assert!(gone.is_none());
+}
+
+/// Regression for the cross-recording revoke bug: before the fix,
+/// `delete_recording_share` took only the digest and happily removed
+/// shares belonging to *any* recording, so any authenticated owner
+/// could revoke another owner's share by hitting the endpoint with
+/// their own `recording_id`. The scoped delete now returns `false`
+/// (→ 404 at the HTTP layer) for a mismatched `recording_id` and
+/// leaves the share intact.
+#[tokio::test]
+async fn recording_storage_delete_share_is_scoped_to_recording_id() {
+    let store = setup().await;
+    let (user_id, session_id) = seed(&store).await;
+
+    // Two recordings so we can try to revoke one's share using the
+    // other's id.
+    let rec_a = store
+        .create_recording(
+            "rec_scope_a",
+            &session_id,
+            user_id,
+            80,
+            24,
+            "/tmp/scope_a.cast",
+            None,
+        )
+        .await
+        .unwrap();
+    let rec_b = store
+        .create_recording(
+            "rec_scope_b",
+            &session_id,
+            user_id,
+            80,
+            24,
+            "/tmp/scope_b.cast",
+            None,
+        )
+        .await
+        .unwrap();
+
+    store
+        .create_recording_share(&rec_a.id, "hash_victim", 0, None)
+        .await
+        .unwrap();
+
+    // Mismatched recording id must NOT remove anything.
+    let deleted = store
+        .delete_recording_share(&rec_b.id, "hash_victim")
+        .await
+        .unwrap();
+    assert!(
+        !deleted,
+        "revoke with mismatched recording_id must be a no-op"
+    );
+
+    // The victim share is still usable.
+    let still_valid = store
+        .consume_recording_share("hash_victim", &rec_a.id)
+        .await
+        .unwrap();
+    assert!(
+        still_valid.is_some(),
+        "share on rec_a must survive a cross-recording revoke attempt"
+    );
+
+    // Correctly scoped revoke DOES remove the share.
+    let deleted = store
+        .delete_recording_share(&rec_a.id, "hash_victim")
+        .await
+        .unwrap();
+    assert!(deleted);
+    let gone = store
+        .consume_recording_share("hash_victim", &rec_a.id)
         .await
         .unwrap();
     assert!(gone.is_none());
@@ -280,9 +361,11 @@ async fn recording_storage_list_expired_recordings() {
     let store = setup().await;
     let (user_id, session_id) = seed(&store).await;
 
-    // Create one with an already-past expiry
+    // Create one with an already-past expiry and mark it completed —
+    // the TTL cleaner only considers finished rows now, so leaving it
+    // at the default `status = 'recording'` would filter it out.
     let past = "2020-01-01T00:00:00+00:00";
-    store
+    let old = store
         .create_recording(
             "rec_old",
             &session_id,
@@ -294,9 +377,13 @@ async fn recording_storage_list_expired_recordings() {
         )
         .await
         .unwrap();
+    store
+        .complete_recording(&old.id, 1000, 5, 512)
+        .await
+        .unwrap();
 
     // Create one with no expiry (permanent)
-    store
+    let perm = store
         .create_recording(
             "rec_perm_e",
             &session_id,
@@ -308,10 +395,14 @@ async fn recording_storage_list_expired_recordings() {
         )
         .await
         .unwrap();
+    store
+        .complete_recording(&perm.id, 1000, 5, 512)
+        .await
+        .unwrap();
 
     // Create one with future expiry
     let future = "2099-01-01T00:00:00+00:00";
-    store
+    let fut = store
         .create_recording(
             "rec_future",
             &session_id,
@@ -323,10 +414,51 @@ async fn recording_storage_list_expired_recordings() {
         )
         .await
         .unwrap();
+    store
+        .complete_recording(&fut.id, 1000, 5, 512)
+        .await
+        .unwrap();
 
     let expired = store.list_expired_recordings(10).await.unwrap();
     assert_eq!(expired.len(), 1);
     assert_eq!(expired[0].file_path, Some("/tmp/old.cast".to_string()));
+}
+
+/// Defense-in-depth for "the TTL cleaner must never try to delete a
+/// recording that is still being captured." Even if a bad
+/// `expires_at` write or a wall-clock jump makes an active
+/// recording's expiry look past, `list_expired_recordings` filters
+/// `status != 'recording'` so the cleaner doesn't hand that row to
+/// `delete_recording` and rip the writer's file out from under it.
+#[tokio::test]
+async fn recording_storage_list_expired_skips_active_recordings() {
+    let store = setup().await;
+    let (user_id, session_id) = seed(&store).await;
+
+    // Simulate a pathological row: status='recording' with an
+    // already-past `expires_at`. Only the direct SQL update lets us
+    // construct this — the service layer would never mint such a
+    // row — so this is purely about making sure the filter catches
+    // it if it somehow exists.
+    let past = "2020-01-01T00:00:00+00:00";
+    store
+        .create_recording(
+            "rec_active_past",
+            &session_id,
+            user_id,
+            80,
+            24,
+            "/tmp/active_past.cast",
+            Some(past),
+        )
+        .await
+        .unwrap();
+
+    let expired = store.list_expired_recordings(10).await.unwrap();
+    assert!(
+        expired.iter().all(|r| r.status != "recording"),
+        "active recordings must never appear in the expired list; got {expired:?}",
+    );
 }
 
 #[tokio::test]

--- a/crates/telepair-core/tests/recording_test.rs
+++ b/crates/telepair-core/tests/recording_test.rs
@@ -1,0 +1,119 @@
+use bytes::Bytes;
+use telepair_core::recording::{
+    AsciicastHeader, RecordingEvent, RecordingRow, RecordingShareRow, RecordingStatus,
+};
+
+#[test]
+fn asciicast_header_serializes_correctly() {
+    let header = AsciicastHeader {
+        version: 2,
+        width: 120,
+        height: 40,
+        timestamp: 1713264000,
+        env: std::collections::HashMap::from([("TERM".into(), "xterm-256color".into())]),
+        telepair: serde_json::json!({
+            "session_id": "abc123",
+            "owner": {"id": "uuid", "name": "alice"},
+            "input_mode": "multiplexed",
+            "target_name": "default"
+        }),
+    };
+    let json = serde_json::to_string(&header).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["version"], 2);
+    assert_eq!(parsed["width"], 120);
+    assert_eq!(parsed["telepair"]["session_id"], "abc123");
+}
+
+#[test]
+fn recording_event_output_serializes_as_asciicast_v2() {
+    let event = RecordingEvent::Output(Bytes::from_static(b"$ "));
+    let line = event.to_asciicast_line(0.0);
+    assert_eq!(line, r#"[0.000000, "o", "$ "]"#);
+}
+
+#[test]
+fn recording_event_output_escapes_special_chars() {
+    let event = RecordingEvent::Output(Bytes::from_static(b"hello\r\n"));
+    let line = event.to_asciicast_line(1.5);
+    assert_eq!(line, r#"[1.500000, "o", "hello\r\n"]"#);
+}
+
+#[test]
+fn recording_event_resize_serializes() {
+    let event = RecordingEvent::Resize {
+        cols: 120,
+        rows: 30,
+    };
+    let line = event.to_asciicast_line(2.5);
+    assert_eq!(line, r#"[2.500000, "r", "120x30"]"#);
+}
+
+#[test]
+fn recording_event_join_serializes() {
+    let event = RecordingEvent::ParticipantJoin {
+        user_id: "uid1".into(),
+        name: "bob".into(),
+        role: "operator".into(),
+    };
+    let line = event.to_asciicast_line(3.1);
+    assert!(line.starts_with("[3.100000, \"j\", "));
+    assert!(line.contains("\"user_id\":\"uid1\""));
+}
+
+#[test]
+fn recording_event_leave_serializes() {
+    let event = RecordingEvent::ParticipantLeave {
+        user_id: "uid1".into(),
+    };
+    let line = event.to_asciicast_line(5.2);
+    assert!(line.starts_with("[5.200000, \"l\", "));
+    assert!(line.contains("\"user_id\":\"uid1\""));
+}
+
+#[test]
+fn recording_event_chat_serializes() {
+    let event = RecordingEvent::Chat {
+        user_id: "uid1".into(),
+        name: "bob".into(),
+        text: "look here".into(),
+    };
+    let line = event.to_asciicast_line(6.0);
+    assert!(line.starts_with("[6.000000, \"c\", "));
+    assert!(line.contains("\"text\":\"look here\""));
+}
+
+#[test]
+fn recording_status_display() {
+    assert_eq!(RecordingStatus::Recording.as_str(), "recording");
+    assert_eq!(RecordingStatus::Completed.as_str(), "completed");
+    assert_eq!(RecordingStatus::Failed.as_str(), "failed");
+}
+
+// Ensure these types are used (suppress dead_code warnings in tests)
+#[test]
+fn recording_row_and_share_row_are_constructible() {
+    let _row = RecordingRow {
+        id: "id1".into(),
+        session_id: "sess1".into(),
+        status: "recording".into(),
+        file_path: None,
+        file_size: 0,
+        duration_ms: None,
+        width: 120,
+        height: 40,
+        event_count: 0,
+        started_at: "2024-01-01T00:00:00Z".into(),
+        completed_at: None,
+        expires_at: None,
+        created_by: "user1".into(),
+    };
+    let _share = RecordingShareRow {
+        token_sha256: "abc".into(),
+        recording_id: "id1".into(),
+        max_uses: 10,
+        used_count: 0,
+        expires_at: None,
+        created_at: "2024-01-01T00:00:00Z".into(),
+    };
+}

--- a/crates/telepair-gateway/Cargo.toml
+++ b/crates/telepair-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telepair-gateway"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/telepair-gateway/src/http.rs
+++ b/crates/telepair-gateway/src/http.rs
@@ -2224,7 +2224,13 @@ pub async fn start_recording(
                 .await;
         });
     });
-    let recording_tx = crate::recording_writer::spawn_recording_writer(
+    // `spawn_recording_writer` returns a `RecordingSlot` that bundles
+    // the mpsc sender with a shared drop counter. The hub's taps
+    // bump the counter on every back-pressured `try_send`, and the
+    // writer reads it at finalisation to downgrade the recording's
+    // status to `failed` when gaps were introduced — no more silent
+    // "completed" recordings that are missing output.
+    let recording_slot = crate::recording_writer::spawn_recording_writer(
         recording.id.clone(),
         file_path,
         header,
@@ -2233,7 +2239,7 @@ pub async fn start_recording(
     );
 
     // Attach to the hub so the PTY I/O loop starts forwarding events.
-    if let Err(reason) = state.hub.start_recording(&session_id, recording_tx).await {
+    if let Err(reason) = state.hub.start_recording(&session_id, recording_slot).await {
         tracing::warn!(
             session_id,
             recording_id = %recording.id,
@@ -2488,6 +2494,15 @@ pub async fn list_recording_shares(
 /// share link. Owner only. The path parameter is the SHA-256 digest
 /// (as returned by `list_recording_shares`), not the raw token —
 /// putting the raw secret in a URL would leak it into access logs.
+///
+/// The delete is scoped to `(recording_id, token_sha256)` at the
+/// storage layer: a caller can only revoke shares that belong to a
+/// recording they own. Without the scope, one owner could compute
+/// the SHA-256 of any leaked share link (the raw token is the link
+/// itself, not a secret) and revoke it by passing their own
+/// `recording_id` on the URL. A mismatched pair returns 404 so the
+/// cross-recording case is indistinguishable from a truly-unknown
+/// digest.
 pub async fn revoke_recording_share(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -2495,10 +2510,13 @@ pub async fn revoke_recording_share(
 ) -> Result<impl IntoResponse, ApiError> {
     let user = extract_user(&state, &headers).await?;
     require_recording_access(&state, &recording_id, &user, false).await?;
-    state
+    let deleted = state
         .recording
-        .delete_share_by_sha256(&token_sha256)
+        .delete_share_by_sha256(&recording_id, &token_sha256)
         .await?;
+    if !deleted {
+        return Err(ApiError::bare(StatusCode::NOT_FOUND));
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/telepair-gateway/src/http.rs
+++ b/crates/telepair-gateway/src/http.rs
@@ -15,8 +15,9 @@ use telepair_control::invite_service::CreateInviteParams;
 use telepair_control::user_target_service::{CreateTargetParams, UpdateTargetParams};
 use telepair_core::error::Error;
 use telepair_core::permission::Role;
+use telepair_core::protocol::ServerMessage;
 use telepair_core::session::{InputMode, SessionListFilter, SessionStatus, User};
-use telepair_core::storage::{AccountFilter, AccountStatus};
+use telepair_core::storage::{AccountFilter, AccountStatus, Storage};
 use telepair_core::target::TargetKind;
 
 use uuid::Uuid;
@@ -275,38 +276,7 @@ pub async fn register(
     body: Result<Json<RegisterRequest>, JsonRejection>,
 ) -> Result<impl IntoResponse, ApiError> {
     let Json(body) = body?;
-
-    // Only enforce the IP throttle when we actually know the caller's
-    // address. If either piece is missing we skip the gate rather than
-    // reject the request — a production deployment that forgot to wire
-    // ConnectInfo would lock out every signup, and the per-email
-    // limiter inside `AuthService::register` still covers the most
-    // common "same user, mashing the button" shape.
-    //
-    // When `trust_forwarded_headers` is on, the key IP is pulled from
-    // `X-Forwarded-For` / `X-Real-IP` instead of the socket peer —
-    // otherwise the recommended "nginx in front of telepair" shape
-    // collapses every caller onto 127.0.0.1 and the whole fleet shares
-    // one bucket (see `resolve_client_ip`).
-    let client_ip = resolve_client_ip(&state, &headers, client_addr);
-    if let (Some(limiter), Some(ip)) = (state.register_rl.as_ref(), client_ip) {
-        use crate::rate_limit::RateLimitDecision;
-        if let RateLimitDecision::Throttled { retry_after } = limiter.check(ip) {
-            // Round up to the next 10-second bucket instead of leaking
-            // exact seconds. The precise remainder lets an attacker
-            // infer how recent their last probe was (a low-resolution
-            // timing oracle); 10s granularity is fine for the UX — a
-            // human retrying a form doesn't need second-accurate
-            // feedback — and clamped to at least 10 so the bucket is
-            // always meaningful.
-            let raw = retry_after.as_secs().max(1);
-            let secs = raw.div_ceil(10) * 10;
-            return Err(ApiError::with_message(
-                StatusCode::TOO_MANY_REQUESTS,
-                format!("Too many registrations from this address. Try again in {secs}s."),
-            ));
-        }
-    }
+    enforce_auth_rate_limit(&state, &headers, client_addr, "registrations")?;
 
     state
         .auth_service
@@ -318,6 +288,44 @@ pub async fn register(
     ))
 }
 
+/// Per-IP throttle for unauthenticated auth endpoints. Used by
+/// `register`, `login`, and `verify_otp` so a single host cannot
+/// brute-force OTP codes or run credential stuffing against many
+/// accounts. Skips silently when ConnectInfo is missing (test
+/// harnesses) or no limiter is configured — the per-email/per-user
+/// limits inside AuthService still cover the most common shapes,
+/// and rejecting everything in those cases would lock out every
+/// signup behind a misconfigured proxy.
+fn enforce_auth_rate_limit(
+    state: &AppState,
+    headers: &HeaderMap,
+    client_addr: Option<std::net::SocketAddr>,
+    surface: &'static str,
+) -> Result<(), ApiError> {
+    // Skip header parsing entirely when no limiter is configured —
+    // every test fixture and the default single-node config land
+    // here, and `resolve_client_ip` parses headers + a SocketAddr.
+    let Some(limiter) = state.auth_rl.as_ref() else {
+        return Ok(());
+    };
+    let Some(ip) = resolve_client_ip(state, headers, client_addr) else {
+        return Ok(());
+    };
+    use crate::rate_limit::RateLimitDecision;
+    if let RateLimitDecision::Throttled { retry_after } = limiter.check(ip) {
+        // Round up to the next 10-second bucket instead of leaking
+        // exact seconds — the precise remainder is a low-resolution
+        // timing oracle, and the user only needs ballpark feedback.
+        let raw = retry_after.as_secs().max(1);
+        let secs = raw.div_ceil(10) * 10;
+        return Err(ApiError::with_message(
+            StatusCode::TOO_MANY_REQUESTS,
+            format!("Too many {surface} from this address. Try again in {secs}s."),
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Deserialize)]
 pub struct VerifyOtpRequest {
     pub email: String,
@@ -327,9 +335,16 @@ pub struct VerifyOtpRequest {
 /// `POST /api/auth/verify` — submit OTP code; returns bearer token on success.
 pub async fn verify_otp(
     State(state): State<AppState>,
+    OptionalClientAddr(client_addr): OptionalClientAddr,
+    headers: HeaderMap,
     body: Result<Json<VerifyOtpRequest>, JsonRejection>,
 ) -> Result<impl IntoResponse, ApiError> {
     let Json(body) = body?;
+    // Per-IP throttle so a 6-digit OTP (10⁶ space) cannot be
+    // exhausted in minutes by parallel attempts from the same host
+    // for a known email — the per-email AuthService rate limit only
+    // covers "same email mashing the button".
+    enforce_auth_rate_limit(&state, &headers, client_addr, "verification attempts")?;
     let token = state
         .auth_service
         .verify_otp(&body.email, &body.code)
@@ -348,9 +363,15 @@ pub struct LoginRequest {
 
 pub async fn login(
     State(state): State<AppState>,
+    OptionalClientAddr(client_addr): OptionalClientAddr,
+    headers: HeaderMap,
     body: Result<Json<LoginRequest>, JsonRejection>,
 ) -> Result<impl IntoResponse, ApiError> {
     let Json(body) = body?;
+    // Per-IP throttle so credential stuffing across many distinct
+    // accounts from the same host does not slip past the per-user
+    // 5-strike lockout that lives inside AuthService::login.
+    enforce_auth_rate_limit(&state, &headers, client_addr, "login attempts")?;
     let token = if let Some(t) = body.token {
         // Validate existing bearer token (admin / guest path).
         state.auth.validate(&t).await?;
@@ -2120,6 +2141,444 @@ pub async fn export_audit(
 }
 
 // --- Admin system info ---
+
+// ── Recording endpoints ──────────────────────────────────────────────────────
+
+/// Fetch a recording by id and enforce access. Returns the row on
+/// success; 404 if missing, 403 if the caller is neither the owner nor
+/// (when `admin_allowed`) an admin.
+async fn require_recording_access(
+    state: &AppState,
+    recording_id: &str,
+    user: &User,
+    admin_allowed: bool,
+) -> Result<telepair_core::recording::RecordingRow, ApiError> {
+    let recording = state
+        .recording
+        .get_recording(recording_id)
+        .await?
+        .ok_or(ApiError::bare(StatusCode::NOT_FOUND))?;
+    let is_owner = recording.created_by == user.id.to_string();
+    let is_admin = admin_allowed && user.is_admin;
+    if !is_owner && !is_admin {
+        return Err(ApiError::bare(StatusCode::FORBIDDEN));
+    }
+    Ok(recording)
+}
+
+/// `POST /api/sessions/{session_id}/recording/start`
+///
+/// Owner-only. Starts recording for an active session. Creates a DB
+/// row, builds the asciicast header, spawns the writer task, and
+/// attaches the recording channel to the hub's PTY tap. Broadcasts
+/// `RecordingStarted` to all connected participants.
+pub async fn start_recording(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(session_id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = extract_user(&state, &headers).await?;
+    // Owner + active gate — mirrors `require_active_owned`.
+    state
+        .sessions
+        .require_active_owned(&user, &session_id)
+        .await?;
+
+    // Honour the server-wide `--recording-enabled` flag. Without this
+    // gate the CLI option silently does nothing and operators who
+    // disabled recording would still see new `.cast` files appear.
+    if !state.recording.should_record(None) {
+        return Err(ApiError::with_message(
+            StatusCode::FORBIDDEN,
+            "session recording is disabled on this server",
+        ));
+    }
+
+    // Use the live PTY size so the asciicast header and DB row match
+    // the actual terminal — playback viewports key off these values.
+    let (cols, rows) = state.hub.pty_size(&session_id).await.unwrap_or((80, 24));
+
+    // Create the recording row (enforces one-active-per-session inside
+    // RecordingService::create_recording).
+    let recording = state
+        .recording
+        .create_recording(&session_id, user.id, i64::from(cols), i64::from(rows))
+        .await?;
+
+    let header = state
+        .recording
+        .build_header(&session_id, &recording.id, cols, rows);
+    let file_path = state.recording.recording_file_path(&recording.id);
+
+    // If the writer aborts (file create / write / flush failure) it
+    // calls this cleanup so the hub releases its sender slot,
+    // letting the owner start a new recording without restarting
+    // the session. Without it the slot stays bound to a dead writer
+    // and every subsequent start/stop returns CONFLICT/NOT_FOUND.
+    let hub_for_cleanup = state.hub.clone();
+    let session_id_for_cleanup = session_id.clone();
+    let on_failure: crate::recording_writer::OnFailure = Box::new(move || {
+        tokio::spawn(async move {
+            hub_for_cleanup
+                .clear_recording_slot(&session_id_for_cleanup)
+                .await;
+        });
+    });
+    let recording_tx = crate::recording_writer::spawn_recording_writer(
+        recording.id.clone(),
+        file_path,
+        header,
+        state.storage.clone(),
+        on_failure,
+    );
+
+    // Attach to the hub so the PTY I/O loop starts forwarding events.
+    if let Err(reason) = state.hub.start_recording(&session_id, recording_tx).await {
+        tracing::warn!(
+            session_id,
+            recording_id = %recording.id,
+            reason,
+            "failed to attach recording to hub, rolling back"
+        );
+        let _ = state.storage.fail_recording(&recording.id).await;
+        return Err(ApiError::with_message(
+            StatusCode::CONFLICT,
+            reason.to_string(),
+        ));
+    }
+
+    // Broadcast to all participants so UIs show the recording indicator.
+    state
+        .hub
+        .broadcast_collab(
+            &session_id,
+            ServerMessage::RecordingStarted {
+                recording_id: recording.id.clone(),
+            },
+        )
+        .await;
+
+    // Audit.
+    state
+        .audit
+        .record(
+            telepair_core::audit::AuditEvent::new(
+                telepair_core::audit::AuditEventType::RecordingStarted,
+            )
+            .with_actor(user.id, user.name.clone())
+            .with_session(session_id)
+            .with_detail(serde_json::json!({
+                "recording_id": recording.id,
+            })),
+        )
+        .await;
+
+    Ok((StatusCode::CREATED, Json(recording)))
+}
+
+/// `POST /api/sessions/{session_id}/recording/stop`
+///
+/// Owner-only. Stops the active recording for a session. Detaches from
+/// the hub, broadcasts `RecordingStopped`, and the writer task flushes
+/// and finalizes the DB row asynchronously.
+pub async fn stop_recording(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(session_id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = extract_user(&state, &headers).await?;
+    state
+        .sessions
+        .require_active_owned(&user, &session_id)
+        .await?;
+
+    // Find the active recording so we can broadcast its id.
+    let recording = state
+        .storage
+        .find_active_recording(&session_id)
+        .await?
+        .ok_or(ApiError::with_message(
+            StatusCode::NOT_FOUND,
+            "no active recording for this session",
+        ))?;
+
+    // Detach from the hub — sends RecordingEvent::Stop to the writer.
+    if let Err(reason) = state.hub.stop_recording(&session_id).await {
+        tracing::warn!(
+            session_id,
+            recording_id = %recording.id,
+            reason,
+            "failed to detach recording from hub"
+        );
+        return Err(ApiError::with_message(
+            StatusCode::CONFLICT,
+            reason.to_string(),
+        ));
+    }
+
+    // Broadcast to all participants.
+    state
+        .hub
+        .broadcast_collab(
+            &session_id,
+            ServerMessage::RecordingStopped {
+                recording_id: recording.id.clone(),
+            },
+        )
+        .await;
+
+    // Audit.
+    state
+        .audit
+        .record(
+            telepair_core::audit::AuditEvent::new(
+                telepair_core::audit::AuditEventType::RecordingStopped,
+            )
+            .with_actor(user.id, user.name.clone())
+            .with_session(session_id)
+            .with_detail(serde_json::json!({
+                "recording_id": recording.id,
+            })),
+        )
+        .await;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /api/recordings` — list recordings created by the authenticated user.
+pub async fn list_recordings(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = extract_user(&state, &headers).await?;
+    let rows = state.recording.list_for_user(user.id).await?;
+    Ok(Json(rows))
+}
+
+/// `GET /api/recordings/{id}` — get recording metadata. Owner or admin.
+pub async fn get_recording(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(recording_id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = extract_user(&state, &headers).await?;
+    let recording = require_recording_access(&state, &recording_id, &user, true).await?;
+    Ok(Json(recording))
+}
+
+/// `DELETE /api/recordings/{id}` — delete a recording. Owner or admin.
+pub async fn delete_recording(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(recording_id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = extract_user(&state, &headers).await?;
+    require_recording_access(&state, &recording_id, &user, true).await?;
+    state.recording.delete_recording(&recording_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Query parameter for `GET /api/recordings/{id}/data`.
+#[derive(Deserialize, Default)]
+pub struct RecordingDataQuery {
+    /// Share token — when present, no auth header is needed.
+    #[serde(default)]
+    pub token: Option<String>,
+}
+
+/// `GET /api/recordings/{id}/data` — download the .cast file.
+///
+/// Supports two access modes:
+/// 1. Auth header: owner or admin can download directly.
+/// 2. `?token=<share_token>`: validates the share token (expiry +
+///    usage) without requiring auth. This powers share links.
+pub async fn get_recording_data(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(recording_id): Path<String>,
+    Query(query): Query<RecordingDataQuery>,
+) -> Result<Response, ApiError> {
+    // Try share-token path first (no auth required). The recording
+    // id is passed to `validate_share_token` so the
+    // recording-mismatch check happens *inside* the same atomic
+    // UPDATE that consumes a use — without this, an attacker holding
+    // a valid token for recording A could burn its quota by hitting
+    // recording B's URL.
+    if let Some(ref raw_token) = query.token {
+        state
+            .recording
+            .validate_share_token(raw_token, &recording_id)
+            .await?;
+    } else {
+        // Auth-header path: owner or admin.
+        let user = extract_user(&state, &headers).await?;
+        require_recording_access(&state, &recording_id, &user, true).await?;
+    }
+
+    let file_path = state.recording.recording_file_path(&recording_id);
+    let data = tokio::fs::read(&file_path).await.map_err(|e| {
+        tracing::warn!(
+            recording_id,
+            path = %file_path.display(),
+            error = %e,
+            "failed to read recording file"
+        );
+        ApiError::bare(StatusCode::NOT_FOUND)
+    })?;
+
+    axum::http::Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/x-asciicast")
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{recording_id}.cast\""),
+        )
+        .body(axum::body::Body::from(data))
+        .map_err(|_| ApiError::bare(StatusCode::INTERNAL_SERVER_ERROR))
+}
+
+/// Request body for `POST /api/recordings/{id}/shares`.
+#[derive(Deserialize)]
+pub struct CreateShareRequest {
+    #[serde(default)]
+    pub max_uses: Option<i64>,
+    #[serde(default)]
+    pub expires_at: Option<String>,
+}
+
+/// `POST /api/recordings/{id}/shares` — create a share link. Owner only.
+pub async fn create_recording_share(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(recording_id): Path<String>,
+    body: Result<Json<CreateShareRequest>, JsonRejection>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = extract_user(&state, &headers).await?;
+    require_recording_access(&state, &recording_id, &user, false).await?;
+
+    let Json(body) = body?;
+    let max_uses = body.max_uses.unwrap_or(0); // 0 = unlimited
+    let (raw_token, share) = state
+        .recording
+        .create_share(&recording_id, max_uses, body.expires_at.as_deref())
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(serde_json::json!({
+            "token": raw_token,
+            "share": share,
+        })),
+    ))
+}
+
+/// `GET /api/recordings/{id}/shares` — list share links. Owner only.
+pub async fn list_recording_shares(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(recording_id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = extract_user(&state, &headers).await?;
+    require_recording_access(&state, &recording_id, &user, false).await?;
+    let shares = state.recording.list_shares(&recording_id).await?;
+    Ok(Json(shares))
+}
+
+/// `DELETE /api/recordings/{id}/shares/{token_sha256}` — revoke a
+/// share link. Owner only. The path parameter is the SHA-256 digest
+/// (as returned by `list_recording_shares`), not the raw token —
+/// putting the raw secret in a URL would leak it into access logs.
+pub async fn revoke_recording_share(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((recording_id, token_sha256)): Path<(String, String)>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = extract_user(&state, &headers).await?;
+    require_recording_access(&state, &recording_id, &user, false).await?;
+    state
+        .recording
+        .delete_share_by_sha256(&token_sha256)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /api/recordings/{id}/keep` — mark a recording as permanent
+/// (clear `expires_at`). Owner or admin. Returns the updated row so
+/// the UI can refresh without a round-trip re-fetch.
+pub async fn keep_recording(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(recording_id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = extract_user(&state, &headers).await?;
+    require_recording_access(&state, &recording_id, &user, true).await?;
+
+    state.recording.set_permanent(&recording_id).await?;
+    let updated = state
+        .recording
+        .get_recording(&recording_id)
+        .await?
+        .ok_or(ApiError::bare(StatusCode::NOT_FOUND))?;
+    Ok(Json(updated))
+}
+
+/// `POST /api/recordings/{id}/expire` — restore TTL on a recording.
+/// Sets `expires_at` to now + configured TTL. Owner or admin. Returns
+/// the updated row.
+pub async fn expire_recording(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(recording_id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = extract_user(&state, &headers).await?;
+    require_recording_access(&state, &recording_id, &user, true).await?;
+
+    let expires_at = state
+        .recording
+        .compute_expires_at()
+        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+    state
+        .recording
+        .set_expiry(&recording_id, &expires_at)
+        .await?;
+    let updated = state
+        .recording
+        .get_recording(&recording_id)
+        .await?
+        .ok_or(ApiError::bare(StatusCode::NOT_FOUND))?;
+    Ok(Json(updated))
+}
+
+/// `GET /api/admin/recordings` — admin-only. Lists every recording in the system.
+pub async fn list_admin_recordings(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = extract_user(&state, &headers).await?;
+    require_admin(&user)?;
+    let rows = state.recording.list_all().await?;
+    Ok(Json(rows))
+}
+
+/// `DELETE /api/admin/recordings/{id}` — admin-only force-delete.
+pub async fn delete_admin_recording(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(recording_id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = extract_user(&state, &headers).await?;
+    require_admin(&user)?;
+
+    // Verify recording exists so we don't silently 204 on a typo.
+    state
+        .recording
+        .get_recording(&recording_id)
+        .await?
+        .ok_or(ApiError::bare(StatusCode::NOT_FOUND))?;
+
+    state.recording.delete_recording(&recording_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
 
 /// `GET /api/admin/system` — admin-only. Returns a snapshot of
 /// server-level diagnostics: version, filesystem paths, SMTP status,

--- a/crates/telepair-gateway/src/lib.rs
+++ b/crates/telepair-gateway/src/lib.rs
@@ -2,6 +2,8 @@
 
 pub mod http;
 pub mod rate_limit;
+pub mod recording_cleaner;
+pub mod recording_writer;
 pub mod session_hub;
 pub mod state;
 pub mod ws;
@@ -144,6 +146,43 @@ pub fn build_router_with_options(
             delete(http::revoke_session_invite),
         )
         .route("/api/invite/redeem", post(http::redeem_invite))
+        // Recording control (owner-only)
+        .route(
+            "/api/sessions/{session_id}/recording/start",
+            post(http::start_recording),
+        )
+        .route(
+            "/api/sessions/{session_id}/recording/stop",
+            post(http::stop_recording),
+        )
+        // Recording CRUD
+        .route("/api/recordings", get(http::list_recordings))
+        .route(
+            "/api/recordings/{recording_id}",
+            get(http::get_recording).delete(http::delete_recording),
+        )
+        .route(
+            "/api/recordings/{recording_id}/data",
+            get(http::get_recording_data),
+        )
+        // Share management (owner-only)
+        .route(
+            "/api/recordings/{recording_id}/shares",
+            post(http::create_recording_share).get(http::list_recording_shares),
+        )
+        .route(
+            "/api/recordings/{recording_id}/shares/{token}",
+            delete(http::revoke_recording_share),
+        )
+        // Recording lifecycle (owner + admin)
+        .route(
+            "/api/recordings/{recording_id}/keep",
+            post(http::keep_recording),
+        )
+        .route(
+            "/api/recordings/{recording_id}/expire",
+            post(http::expire_recording),
+        )
         // Admin-only target management. Both handlers gate on
         // `is_admin` after `extract_user`, so unauthenticated callers
         // still get 401 from the shared extractor and non-admin
@@ -156,6 +195,11 @@ pub fn build_router_with_options(
         .route("/api/admin/audit", get(http::list_admin_audit))
         .route("/api/admin/audit/export", get(http::export_audit))
         .route("/api/admin/system", get(http::system_info))
+        .route("/api/admin/recordings", get(http::list_admin_recordings))
+        .route(
+            "/api/admin/recordings/{recording_id}",
+            delete(http::delete_admin_recording),
+        )
         .route("/api/admin/users", get(http::list_admin_users))
         .route(
             "/api/admin/users/{id}/enable",

--- a/crates/telepair-gateway/src/recording_cleaner.rs
+++ b/crates/telepair-gateway/src/recording_cleaner.rs
@@ -130,6 +130,9 @@ mod tests {
             .unwrap();
 
         // One expired recording: row + file that the cleaner should erase.
+        // Completed so the TTL cleaner's status filter lets it
+        // through — an in-progress recording must never be handed to
+        // the cleaner, even with a past `expires_at`.
         let expired_id = "rec_ttl_expired";
         let expired_file = format!("{expired_id}.cast");
         let expired_path = dir.path().join(&expired_file);
@@ -146,6 +149,10 @@ mod tests {
             )
             .await
             .unwrap();
+        storage
+            .complete_recording(expired_id, 1000, 5, 512)
+            .await
+            .unwrap();
 
         // One permanent recording the cleaner must NOT touch.
         let keep_id = "rec_ttl_keep";
@@ -154,6 +161,10 @@ mod tests {
         std::fs::write(&keep_path, b"keep").unwrap();
         storage
             .create_recording(keep_id, &session.id, user.id, 80, 24, &keep_file, None)
+            .await
+            .unwrap();
+        storage
+            .complete_recording(keep_id, 1000, 5, 512)
             .await
             .unwrap();
 
@@ -204,6 +215,10 @@ mod tests {
             )
             .await
             .unwrap();
+        // Mark completed so the cleaner's status filter lets it
+        // through — active recordings are now excluded at the
+        // listing layer.
+        storage.complete_recording(id, 1000, 5, 512).await.unwrap();
 
         // No file written — run should still drop the row.
         run_once(&storage, dir.path()).await;

--- a/crates/telepair-gateway/src/recording_cleaner.rs
+++ b/crates/telepair-gateway/src/recording_cleaner.rs
@@ -1,0 +1,213 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use telepair_core::storage::{SqliteStorage, Storage};
+
+/// How many expired recordings to process per run. A batch cap keeps
+/// each run O(batch) in memory rather than loading every expired row at
+/// once when the server has been offline for a long period.
+const BATCH_LIMIT: i64 = 100;
+
+/// Spawn the background TTL cleaner that periodically deletes recordings
+/// whose `expires_at` has passed. The task runs immediately on startup
+/// (to clear any expired rows from a prior period), then once per hour.
+///
+/// Errors are logged but never propagate — a failure in one batch must
+/// not crash the server or block the next scheduled run.
+///
+/// `dir` is the recording directory on disk; files matching
+/// `{dir}/{recording_id}.cast` are removed before the DB row is deleted.
+pub fn spawn_recording_cleaner(storage: Arc<SqliteStorage>, dir: PathBuf) {
+    tokio::spawn(async move {
+        // Run immediately on startup to handle any backlog from a
+        // previous server run, then switch to the hourly cadence.
+        run_once(&storage, &dir).await;
+
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(3600));
+        // First tick fires immediately; skip it so we don't double-clean
+        // on startup.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            run_once(&storage, &dir).await;
+        }
+    });
+}
+
+async fn run_once(storage: &Arc<SqliteStorage>, dir: &std::path::Path) {
+    let expired = match storage.list_expired_recordings(BATCH_LIMIT).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!(error = %e, "TTL cleaner: failed to query expired recordings");
+            return;
+        }
+    };
+
+    if expired.is_empty() {
+        return;
+    }
+
+    tracing::info!(
+        count = expired.len(),
+        "TTL cleaner: deleting expired recordings"
+    );
+
+    for rec in expired {
+        // Best-effort file removal. A missing file is not an error — it
+        // may have been cleaned up by another process or a previous
+        // partial run. Any other I/O failure is logged as a warning and
+        // we still proceed with the DB deletion so the row doesn't
+        // accumulate indefinitely.
+        if let Some(ref path_str) = rec.file_path {
+            let path = PathBuf::from(path_str);
+            // If the stored path is relative, resolve it against `dir`.
+            let abs_path = if path.is_absolute() {
+                path
+            } else {
+                dir.join(path)
+            };
+            match std::fs::remove_file(&abs_path) {
+                Ok(()) => {
+                    tracing::debug!(
+                        recording_id = %rec.id,
+                        path = %abs_path.display(),
+                        "TTL cleaner: removed recording file"
+                    );
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    tracing::warn!(
+                        recording_id = %rec.id,
+                        path = %abs_path.display(),
+                        "TTL cleaner: recording file not found (already removed?)"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        recording_id = %rec.id,
+                        path = %abs_path.display(),
+                        error = %e,
+                        "TTL cleaner: failed to remove recording file"
+                    );
+                }
+            }
+        }
+
+        // Delete the DB row. Cascade deletes associated `recording_shares`
+        // rows. A failure here is an error (the file is gone but the row
+        // lingers) — log it so an operator can investigate and re-run.
+        if let Err(e) = storage.delete_recording(&rec.id).await {
+            tracing::error!(
+                recording_id = %rec.id,
+                error = %e,
+                "TTL cleaner: failed to delete recording row"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use telepair_core::session::InputMode;
+    use telepair_core::storage::Storage;
+
+    /// End-to-end check that the cleaner removes both the on-disk
+    /// `.cast` file and the DB row for an expired recording, while
+    /// leaving non-expired ones alone. This pins the contract that
+    /// the recording id used in `file_path` matches the row id —
+    /// the previous bug minted them separately and the cleaner
+    /// wiped the row but left the file behind.
+    #[tokio::test]
+    async fn cleaner_removes_expired_file_and_row_but_spares_others() {
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let dir = tempfile::tempdir().unwrap();
+
+        // Seed a user + session.
+        let (user, _) = storage.create_user("ttluser", false).await.unwrap();
+        let session = storage
+            .create_session_with_owner(user.id, "default", InputMode::Serialized, None)
+            .await
+            .unwrap();
+
+        // One expired recording: row + file that the cleaner should erase.
+        let expired_id = "rec_ttl_expired";
+        let expired_file = format!("{expired_id}.cast");
+        let expired_path = dir.path().join(&expired_file);
+        std::fs::write(&expired_path, b"expired").unwrap();
+        storage
+            .create_recording(
+                expired_id,
+                &session.id,
+                user.id,
+                80,
+                24,
+                &expired_file,
+                Some("2020-01-01T00:00:00+00:00"),
+            )
+            .await
+            .unwrap();
+
+        // One permanent recording the cleaner must NOT touch.
+        let keep_id = "rec_ttl_keep";
+        let keep_file = format!("{keep_id}.cast");
+        let keep_path = dir.path().join(&keep_file);
+        std::fs::write(&keep_path, b"keep").unwrap();
+        storage
+            .create_recording(keep_id, &session.id, user.id, 80, 24, &keep_file, None)
+            .await
+            .unwrap();
+
+        run_once(&storage, dir.path()).await;
+
+        assert!(
+            !expired_path.exists(),
+            "expired .cast file should be deleted"
+        );
+        assert!(
+            storage.get_recording(expired_id).await.unwrap().is_none(),
+            "expired DB row should be deleted"
+        );
+        assert!(keep_path.exists(), "permanent .cast file must survive");
+        assert!(
+            storage.get_recording(keep_id).await.unwrap().is_some(),
+            "permanent DB row must survive"
+        );
+    }
+
+    /// A missing file is documented as "not an error" — the cleaner
+    /// must still remove the row so it does not accumulate
+    /// indefinitely after manual file deletion or a partial prior
+    /// run. This is the behaviour the cleaner already relies on; the
+    /// test pins it so a future refactor doesn't quietly start
+    /// returning early on `NotFound`.
+    #[tokio::test]
+    async fn cleaner_removes_row_when_file_missing() {
+        let storage = Arc::new(SqliteStorage::new_memory().await.unwrap());
+        let dir = tempfile::tempdir().unwrap();
+
+        let (user, _) = storage.create_user("nofileuser", false).await.unwrap();
+        let session = storage
+            .create_session_with_owner(user.id, "default", InputMode::Serialized, None)
+            .await
+            .unwrap();
+
+        let id = "rec_no_file";
+        storage
+            .create_recording(
+                id,
+                &session.id,
+                user.id,
+                80,
+                24,
+                &format!("{id}.cast"),
+                Some("2020-01-01T00:00:00+00:00"),
+            )
+            .await
+            .unwrap();
+
+        // No file written — run should still drop the row.
+        run_once(&storage, dir.path()).await;
+
+        assert!(storage.get_recording(id).await.unwrap().is_none());
+    }
+}

--- a/crates/telepair-gateway/src/recording_writer.rs
+++ b/crates/telepair-gateway/src/recording_writer.rs
@@ -1,0 +1,404 @@
+/// Async task that drains a [`RecordingEvent`] channel and writes
+/// asciicast v2 NDJSON to a file, flushing periodically and finalising
+/// the database row on completion or error.
+///
+/// Callers obtain an `mpsc::Sender<RecordingEvent>` from
+/// [`spawn_recording_writer`] and feed events into it; the returned
+/// task is detached and runs until the channel closes or a
+/// [`RecordingEvent::Stop`] is received.
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use telepair_core::recording::{AsciicastHeader, RecordingEvent};
+use telepair_core::storage::{SqliteStorage, Storage};
+use tokio::sync::mpsc;
+use tracing::{error, warn};
+
+/// Flush when the unflushed buffer exceeds this many bytes, even if the
+/// 1-second timer has not fired yet.
+const FLUSH_THRESHOLD_BYTES: usize = 64 * 1024;
+
+/// Callback the writer invokes if it aborts due to an I/O failure.
+/// Lets the caller (typically `http::start_recording`) detach the
+/// dead sender from `SessionHub` so the owner can start a new
+/// recording without restarting the session. `Box<dyn FnOnce>` keeps
+/// the writer signature free of generics and lets the spawn site
+/// capture whatever handle it needs (e.g. an `Arc<SessionHub>` plus
+/// the session id) without leaking those types into this module.
+pub type OnFailure = Box<dyn FnOnce() + Send + 'static>;
+
+/// Spawn the recording writer task.
+///
+/// Returns an `mpsc::Sender` the caller should use to feed
+/// [`RecordingEvent`]s. The task ends when either:
+/// - A [`RecordingEvent::Stop`] is received, or
+/// - The sender is dropped (channel closed).
+///
+/// On normal completion the task calls
+/// [`SqliteStorage::complete_recording`]. On any I/O error it calls
+/// [`SqliteStorage::fail_recording`] **and** runs `on_failure` so
+/// the hub can release the recording slot for the owner to retry.
+pub fn spawn_recording_writer(
+    recording_id: String,
+    file_path: PathBuf,
+    header: AsciicastHeader,
+    storage: Arc<SqliteStorage>,
+    on_failure: OnFailure,
+) -> mpsc::Sender<RecordingEvent> {
+    let (tx, rx) = mpsc::channel::<RecordingEvent>(1024);
+    tokio::spawn(run_writer(
+        recording_id,
+        file_path,
+        header,
+        storage,
+        rx,
+        on_failure,
+    ));
+    tx
+}
+
+/// Open the file, write the header, then run the event loop.
+/// Returns `Ok(())` on graceful stop, `Err(())` if an I/O error forced
+/// an early exit (the DB row is already marked `failed` before this
+/// returns).
+async fn run_writer(
+    recording_id: String,
+    file_path: PathBuf,
+    header: AsciicastHeader,
+    storage: Arc<SqliteStorage>,
+    mut rx: mpsc::Receiver<RecordingEvent>,
+    on_failure: OnFailure,
+) {
+    // Hold the cleanup callback in an Option so each failure branch
+    // can `take()` and invoke it exactly once. `OnFailure` is a
+    // `FnOnce`, so duplicate invocation is a compile error — `take`
+    // gives the borrow checker something to work with.
+    let mut on_failure_slot: Option<OnFailure> = Some(on_failure);
+
+    // Every IO failure path runs the same three statements: mark the
+    // DB row failed, run the cleanup so the hub releases its slot,
+    // and bail out of the loop. A macro keeps that contract in one
+    // place — adding a sixth failure branch later cannot quietly
+    // forget the cleanup call.
+    macro_rules! abort_writer {
+        () => {{
+            mark_failed(&storage, &recording_id).await;
+            if let Some(cb) = on_failure_slot.take() {
+                cb();
+            }
+            return;
+        }};
+    }
+
+    // ── Open file ────────────────────────────────────────────────────
+    let file = match std::fs::File::create(&file_path) {
+        Ok(f) => f,
+        Err(e) => {
+            error!(
+                recording_id = %recording_id,
+                path = %file_path.display(),
+                error = %e,
+                "recording writer: failed to create file"
+            );
+            abort_writer!();
+        }
+    };
+    let mut writer = BufWriter::new(file);
+
+    // ── Write header ─────────────────────────────────────────────────
+    let header_bytes = header_written_bytes(&header_json_str(&header));
+    {
+        // Scope ensures format temporaries are gone before the first await.
+        let write_result = write_header(&mut writer, &header);
+        if let Err(e) = write_result {
+            error!(recording_id = %recording_id, error = %e, "recording writer: failed to write header");
+            abort_writer!();
+        }
+    }
+
+    // ── Event loop ───────────────────────────────────────────────────
+    let start = Instant::now();
+    let mut event_count: i64 = 0;
+    let mut bytes_written: usize = header_bytes;
+    let mut unflushed_bytes: usize = 0;
+    let flush_interval = tokio::time::Duration::from_secs(1);
+
+    loop {
+        let recv_result = tokio::time::timeout(flush_interval, rx.recv()).await;
+
+        match recv_result {
+            // 1-second timeout — flush if anything is pending.
+            Err(_timeout) => {
+                if unflushed_bytes > 0 {
+                    let flush_result = writer.flush();
+                    if let Err(e) = flush_result {
+                        error!(recording_id = %recording_id, error = %e, "recording writer: periodic flush failed");
+                        abort_writer!();
+                    }
+                    unflushed_bytes = 0;
+                }
+            }
+
+            // Channel closed (all senders dropped) — treat as graceful stop.
+            Ok(None) => break,
+
+            Ok(Some(RecordingEvent::Stop)) => break,
+
+            Ok(Some(event)) => {
+                let elapsed = start.elapsed().as_secs_f64();
+                let line = event.to_asciicast_line(elapsed);
+                let line_len = line.len() + 1; // +1 for the newline
+
+                // Perform the write and capture the result before any await.
+                let write_result = writeln!(writer, "{line}");
+                if let Err(e) = write_result {
+                    error!(recording_id = %recording_id, error = %e, "recording writer: write failed");
+                    abort_writer!();
+                }
+
+                event_count += 1;
+                bytes_written += line_len;
+                unflushed_bytes += line_len;
+
+                if unflushed_bytes >= FLUSH_THRESHOLD_BYTES {
+                    let flush_result = writer.flush();
+                    if let Err(e) = flush_result {
+                        error!(recording_id = %recording_id, error = %e, "recording writer: threshold flush failed");
+                        abort_writer!();
+                    }
+                    unflushed_bytes = 0;
+                }
+            }
+        }
+    }
+
+    // ── Final flush ──────────────────────────────────────────────────
+    {
+        let flush_result = writer.flush();
+        if let Err(e) = flush_result {
+            error!(recording_id = %recording_id, error = %e, "recording writer: final flush failed");
+            abort_writer!();
+        }
+    }
+    drop(writer);
+    // Graceful path: drop the cleanup explicitly. The hub already
+    // took its slot via `stop_recording`, and dropping the closure
+    // here releases the captured `Arc<SessionHub>` immediately
+    // instead of waiting for the function to return.
+    drop(on_failure_slot);
+
+    // ── Complete DB row ──────────────────────────────────────────────
+    let file_size = std::fs::metadata(&file_path)
+        .map(|m| m.len() as i64)
+        .unwrap_or(bytes_written as i64);
+    let duration_ms = start.elapsed().as_millis() as i64;
+
+    if let Err(e) = storage
+        .complete_recording(&recording_id, duration_ms, event_count, file_size)
+        .await
+    {
+        error!(
+            recording_id = %recording_id,
+            error = %e,
+            "recording writer: complete_recording DB call failed"
+        );
+    }
+}
+
+// ── Helpers (sync, no await) ──────────────────────────────────────────
+
+fn header_json_str(header: &AsciicastHeader) -> String {
+    serde_json::to_string(header).unwrap_or_default()
+}
+
+fn header_written_bytes(json: &str) -> usize {
+    json.len() + 1 // +1 for the trailing newline
+}
+
+fn write_header(
+    writer: &mut BufWriter<std::fs::File>,
+    header: &AsciicastHeader,
+) -> std::io::Result<()> {
+    let json = header_json_str(header);
+    writeln!(writer, "{json}")
+}
+
+async fn mark_failed(storage: &Arc<SqliteStorage>, recording_id: &str) {
+    if let Err(e) = storage.fail_recording(recording_id).await {
+        warn!(recording_id = %recording_id, error = %e, "recording writer: fail_recording DB call failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use std::io::Read;
+    use telepair_core::recording::RecordingEvent;
+    use telepair_core::session::InputMode;
+    use telepair_core::storage::Storage;
+
+    async fn make_storage() -> Arc<SqliteStorage> {
+        Arc::new(SqliteStorage::new_memory().await.unwrap())
+    }
+
+    /// Seed a user + session, returning (user_id, session_id).
+    async fn seed(storage: &Arc<SqliteStorage>, name: &str) -> (uuid::Uuid, String) {
+        let (user, _) = storage.create_user(name, false).await.unwrap();
+        let session = storage
+            .create_session_with_owner(user.id, "default", InputMode::Serialized, None)
+            .await
+            .unwrap();
+        (user.id, session.id)
+    }
+
+    fn make_header() -> AsciicastHeader {
+        AsciicastHeader {
+            version: 2,
+            width: 80,
+            height: 24,
+            timestamp: 0,
+            env: Default::default(),
+            telepair: serde_json::json!({}),
+        }
+    }
+
+    #[tokio::test]
+    async fn writer_creates_file_and_completes() {
+        let storage = make_storage().await;
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        drop(tmp);
+
+        let (user_id, session_id) = seed(&storage, "tester").await;
+        let recording = storage
+            .create_recording(
+                "rec_writer_ok",
+                &session_id,
+                user_id,
+                80,
+                24,
+                &path.to_string_lossy(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let tx = spawn_recording_writer(
+            recording.id.clone(),
+            path.clone(),
+            make_header(),
+            storage.clone(),
+            Box::new(|| {}),
+        );
+
+        tx.send(RecordingEvent::Output(Bytes::from_static(b"hello")))
+            .await
+            .unwrap();
+        tx.send(RecordingEvent::Resize {
+            cols: 100,
+            rows: 30,
+        })
+        .await
+        .unwrap();
+        tx.send(RecordingEvent::Stop).await.unwrap();
+        drop(tx);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        let row = storage.get_recording(&recording.id).await.unwrap().unwrap();
+        assert_eq!(row.status, "completed");
+        assert_eq!(row.event_count, 2); // Output + Resize
+
+        let mut content = String::new();
+        std::fs::File::open(&path)
+            .unwrap()
+            .read_to_string(&mut content)
+            .unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 3, "header + 2 events = 3 lines");
+        assert!(lines[0].contains("\"version\":2"));
+        assert!(lines[1].contains("\"o\""));
+        assert!(lines[2].contains("\"r\""));
+    }
+
+    #[tokio::test]
+    async fn writer_marks_failed_on_bad_path() {
+        let storage = make_storage().await;
+        let (user_id, session_id) = seed(&storage, "tester2").await;
+        let bad_path = PathBuf::from("/nonexistent_dir/recording.cast");
+        let recording = storage
+            .create_recording(
+                "rec_writer_bad",
+                &session_id,
+                user_id,
+                80,
+                24,
+                &bad_path.to_string_lossy(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let cleanup_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let cleanup_flag = cleanup_called.clone();
+        let _tx = spawn_recording_writer(
+            recording.id.clone(),
+            bad_path,
+            make_header(),
+            storage.clone(),
+            Box::new(move || {
+                cleanup_flag.store(true, std::sync::atomic::Ordering::SeqCst);
+            }),
+        );
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        let row = storage.get_recording(&recording.id).await.unwrap().unwrap();
+        assert_eq!(row.status, "failed");
+        assert!(
+            cleanup_called.load(std::sync::atomic::Ordering::SeqCst),
+            "on_failure must run when the writer aborts so the hub releases its slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn writer_completes_on_channel_close() {
+        let storage = make_storage().await;
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        drop(tmp);
+
+        let (user_id, session_id) = seed(&storage, "tester3").await;
+        let recording = storage
+            .create_recording(
+                "rec_writer_close",
+                &session_id,
+                user_id,
+                80,
+                24,
+                &path.to_string_lossy(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let tx = spawn_recording_writer(
+            recording.id.clone(),
+            path,
+            make_header(),
+            storage.clone(),
+            Box::new(|| {}),
+        );
+
+        // Drop the sender without Stop — channel close should trigger graceful completion.
+        drop(tx);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        let row = storage.get_recording(&recording.id).await.unwrap().unwrap();
+        assert_eq!(row.status, "completed");
+    }
+}

--- a/crates/telepair-gateway/src/recording_writer.rs
+++ b/crates/telepair-gateway/src/recording_writer.rs
@@ -2,19 +2,62 @@
 /// asciicast v2 NDJSON to a file, flushing periodically and finalising
 /// the database row on completion or error.
 ///
-/// Callers obtain an `mpsc::Sender<RecordingEvent>` from
-/// [`spawn_recording_writer`] and feed events into it; the returned
-/// task is detached and runs until the channel closes or a
-/// [`RecordingEvent::Stop`] is received.
+/// Callers obtain a [`RecordingSlot`] (sender + shared drop counter)
+/// from [`spawn_recording_writer`] and feed events into it via
+/// `slot.tx`; the PTY tap increments `slot.dropped` on every
+/// back-pressured `try_send`. The returned task runs until the
+/// channel closes or a [`RecordingEvent::Stop`] is received. At
+/// finalisation it reads the drop counter — if any events were
+/// dropped, the recording is marked `failed` rather than
+/// `completed`, so the API/UI never silently serve a capture with
+/// gaps in it.
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use telepair_core::recording::{AsciicastHeader, RecordingEvent};
 use telepair_core::storage::{SqliteStorage, Storage};
 use tokio::sync::mpsc;
 use tracing::{error, warn};
+
+/// Sender + shared drop counter handed back to the hub so the PTY
+/// I/O loop (and any other tap) can report events it had to discard
+/// because the writer's channel was full. The writer task holds a
+/// clone of `dropped` via [`spawn_recording_writer`] and reads it
+/// at finalisation: a non-zero count flips the final status from
+/// `completed` to `failed`, matching the semantics of an I/O
+/// failure — either way the capture is incomplete and callers must
+/// not trust it. Pairing the sender and counter in one struct keeps
+/// the two from drifting out of sync; every tap that uses the `tx`
+/// is the same tap that must bump the counter on failure.
+pub struct RecordingSlot {
+    pub tx: mpsc::Sender<RecordingEvent>,
+    pub dropped: Arc<AtomicU64>,
+}
+
+impl RecordingSlot {
+    /// Non-blocking send that also records back-pressure. Every hub
+    /// tap uses this helper so no call site can forget to bump the
+    /// counter on failure — the previous `let _ = tx.try_send(...)`
+    /// pattern made a lost event indistinguishable from a delivered
+    /// one, and the writer then marked the recording as `completed`
+    /// even when gaps existed. Dropping an event is still safe for
+    /// the PTY I/O loop (the shell does not stall on a slow writer),
+    /// but the slot now remembers the drop so finalisation can
+    /// downgrade the status.
+    pub fn try_send(&self, event: RecordingEvent) {
+        if self.tx.try_send(event).is_err() {
+            // `Relaxed` is sufficient: we only read this counter at
+            // finalisation, under the writer's own mutable context,
+            // after the channel has been closed — no concurrent
+            // increment/read race exists that would benefit from a
+            // stronger ordering.
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
 
 /// Flush when the unflushed buffer exceeds this many bytes, even if the
 /// 1-second timer has not fired yet.
@@ -31,23 +74,33 @@ pub type OnFailure = Box<dyn FnOnce() + Send + 'static>;
 
 /// Spawn the recording writer task.
 ///
-/// Returns an `mpsc::Sender` the caller should use to feed
-/// [`RecordingEvent`]s. The task ends when either:
+/// Returns a [`RecordingSlot`] carrying the sender callers use to
+/// feed [`RecordingEvent`]s AND a shared drop counter the hub's
+/// taps bump whenever back-pressure forces an event to be
+/// discarded. The writer task keeps its own clone of the counter so
+/// it can reflect any lost events into the final DB status. The
+/// task ends when either:
 /// - A [`RecordingEvent::Stop`] is received, or
 /// - The sender is dropped (channel closed).
 ///
-/// On normal completion the task calls
-/// [`SqliteStorage::complete_recording`]. On any I/O error it calls
-/// [`SqliteStorage::fail_recording`] **and** runs `on_failure` so
-/// the hub can release the recording slot for the owner to retry.
+/// On normal completion with zero drops the task calls
+/// [`SqliteStorage::complete_recording`]. If **any** drops were
+/// recorded during the run, the task instead calls
+/// [`SqliteStorage::fail_recording`] — a capture with gaps is not
+/// a "completed" capture, and the API/UI must show it as failed so
+/// the operator treats it with appropriate suspicion. On an I/O
+/// error the same `fail_recording` path runs **and** `on_failure`
+/// executes so the hub can release the recording slot for the
+/// owner to retry.
 pub fn spawn_recording_writer(
     recording_id: String,
     file_path: PathBuf,
     header: AsciicastHeader,
     storage: Arc<SqliteStorage>,
     on_failure: OnFailure,
-) -> mpsc::Sender<RecordingEvent> {
+) -> RecordingSlot {
     let (tx, rx) = mpsc::channel::<RecordingEvent>(1024);
+    let dropped = Arc::new(AtomicU64::new(0));
     tokio::spawn(run_writer(
         recording_id,
         file_path,
@@ -55,8 +108,9 @@ pub fn spawn_recording_writer(
         storage,
         rx,
         on_failure,
+        dropped.clone(),
     ));
-    tx
+    RecordingSlot { tx, dropped }
 }
 
 /// Open the file, write the header, then run the event loop.
@@ -70,6 +124,7 @@ async fn run_writer(
     storage: Arc<SqliteStorage>,
     mut rx: mpsc::Receiver<RecordingEvent>,
     on_failure: OnFailure,
+    dropped: Arc<AtomicU64>,
 ) {
     // Hold the cleanup callback in an Option so each failure branch
     // can `take()` and invoke it exactly once. `OnFailure` is a
@@ -195,6 +250,27 @@ async fn run_writer(
         .unwrap_or(bytes_written as i64);
     let duration_ms = start.elapsed().as_millis() as i64;
 
+    // A non-zero drop count means the PTY I/O loop had to discard
+    // events because this writer's channel was full. The file is
+    // still valid asciicast (we wrote everything we actually
+    // received) but it has gaps the viewer cannot recover. Mark
+    // the recording `failed` so the API/UI refuses to advertise it
+    // as a trustworthy capture — matching how an I/O failure is
+    // handled. Logging the count at `error!` level surfaces the
+    // problem in operator dashboards so repeated drops can drive a
+    // channel-size or writer-tuning response.
+    let dropped_events = dropped.load(Ordering::Relaxed);
+    if dropped_events > 0 {
+        error!(
+            recording_id = %recording_id,
+            dropped_events,
+            event_count,
+            "recording writer: events were dropped under back-pressure; marking recording as failed",
+        );
+        mark_failed(&storage, &recording_id).await;
+        return;
+    }
+
     if let Err(e) = storage
         .complete_recording(&recording_id, duration_ms, event_count, file_size)
         .await
@@ -286,7 +362,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tx = spawn_recording_writer(
+        let slot = spawn_recording_writer(
             recording.id.clone(),
             path.clone(),
             make_header(),
@@ -294,17 +370,19 @@ mod tests {
             Box::new(|| {}),
         );
 
-        tx.send(RecordingEvent::Output(Bytes::from_static(b"hello")))
+        slot.tx
+            .send(RecordingEvent::Output(Bytes::from_static(b"hello")))
             .await
             .unwrap();
-        tx.send(RecordingEvent::Resize {
-            cols: 100,
-            rows: 30,
-        })
-        .await
-        .unwrap();
-        tx.send(RecordingEvent::Stop).await.unwrap();
-        drop(tx);
+        slot.tx
+            .send(RecordingEvent::Resize {
+                cols: 100,
+                rows: 30,
+            })
+            .await
+            .unwrap();
+        slot.tx.send(RecordingEvent::Stop).await.unwrap();
+        drop(slot);
 
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
@@ -344,7 +422,7 @@ mod tests {
 
         let cleanup_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let cleanup_flag = cleanup_called.clone();
-        let _tx = spawn_recording_writer(
+        let _slot = spawn_recording_writer(
             recording.id.clone(),
             bad_path,
             make_header(),
@@ -385,7 +463,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tx = spawn_recording_writer(
+        let slot = spawn_recording_writer(
             recording.id.clone(),
             path,
             make_header(),
@@ -394,11 +472,106 @@ mod tests {
         );
 
         // Drop the sender without Stop — channel close should trigger graceful completion.
-        drop(tx);
+        drop(slot);
 
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
         let row = storage.get_recording(&recording.id).await.unwrap().unwrap();
         assert_eq!(row.status, "completed");
+    }
+
+    /// Regression for "recording output is silently dropped under
+    /// backpressure." Before the fix, every `try_send` failure in
+    /// the PTY I/O loop was swallowed and the writer still marked
+    /// the capture `completed`, so a viewer could load a recording
+    /// with gaps in it and never know. The slot now carries a drop
+    /// counter; at finalisation the writer downgrades the status
+    /// to `failed` if any events were lost. This test bumps the
+    /// counter directly (the easiest way to exercise the
+    /// finalisation branch without fabricating channel
+    /// back-pressure) and asserts the final status reflects the
+    /// drops.
+    #[tokio::test]
+    async fn writer_marks_failed_when_drops_occurred() {
+        let storage = make_storage().await;
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        drop(tmp);
+
+        let (user_id, session_id) = seed(&storage, "tester4").await;
+        let recording = storage
+            .create_recording(
+                "rec_writer_dropped",
+                &session_id,
+                user_id,
+                80,
+                24,
+                &path.to_string_lossy(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let slot = spawn_recording_writer(
+            recording.id.clone(),
+            path.clone(),
+            make_header(),
+            storage.clone(),
+            Box::new(|| {}),
+        );
+
+        // Send one real event so the file is well-formed asciicast,
+        // then simulate a drop. A partial capture is still a partial
+        // capture — the fix must flip to `failed` regardless of
+        // whether any bytes made it through.
+        slot.tx
+            .send(RecordingEvent::Output(Bytes::from_static(b"partial")))
+            .await
+            .unwrap();
+        slot.dropped
+            .fetch_add(3, std::sync::atomic::Ordering::Relaxed);
+        slot.tx.send(RecordingEvent::Stop).await.unwrap();
+        drop(slot);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        let row = storage.get_recording(&recording.id).await.unwrap().unwrap();
+        assert_eq!(
+            row.status, "failed",
+            "writer must mark recording as failed when any events were dropped; got {row:?}",
+        );
+    }
+
+    /// `RecordingSlot::try_send` is the single gate the hub taps
+    /// use to report back-pressure. Pin both sides of the
+    /// contract: a successful send does NOT bump the counter, and a
+    /// send into a full channel DOES. Without this test a future
+    /// refactor could silently strip the counter bump (the old
+    /// failure mode) or double-count on success.
+    #[tokio::test]
+    async fn try_send_bumps_counter_only_on_backpressure() {
+        // Tiny channel so we can fill it deterministically without
+        // racing the writer task. No writer is spawned here — we
+        // construct the slot by hand to exercise `try_send` in
+        // isolation.
+        let (tx, _rx) = mpsc::channel::<RecordingEvent>(1);
+        let dropped = Arc::new(AtomicU64::new(0));
+        let slot = RecordingSlot {
+            tx,
+            dropped: dropped.clone(),
+        };
+
+        // First send fits in the buffer — counter stays at zero.
+        slot.try_send(RecordingEvent::Output(Bytes::from_static(b"a")));
+        assert_eq!(dropped.load(Ordering::Relaxed), 0);
+
+        // Second send overflows the buffer (nothing drains because
+        // there's no receiver task reading).
+        slot.try_send(RecordingEvent::Output(Bytes::from_static(b"b")));
+        assert_eq!(
+            dropped.load(Ordering::Relaxed),
+            1,
+            "a full-channel try_send must increment the drop counter",
+        );
     }
 }

--- a/crates/telepair-gateway/src/session_hub.rs
+++ b/crates/telepair-gateway/src/session_hub.rs
@@ -8,6 +8,7 @@ use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use uuid::Uuid;
 
+use crate::recording_writer::RecordingSlot;
 use telepair_agent::pty::PtyManager;
 use telepair_control::session_service::SessionService;
 use telepair_core::error::Result;
@@ -273,15 +274,21 @@ struct LiveSession {
     /// every recording was stamped 80×24 regardless of the real
     /// session size and playback rendered at the wrong aspect.
     pty_size: Arc<Mutex<(u16, u16)>>,
-    /// Channel for sending recording events to the `RecordingWriter`
-    /// task. `None` when no recording is active. Wrapped in
-    /// `Arc<Mutex<_>>` so the PTY I/O loop (which captures a clone of
-    /// the Arc at spawn time) and the `start_recording` / `stop_recording`
-    /// public methods can both read/write it without holding the
-    /// sessions RwLock. The inner Mutex is std (not tokio) because the
-    /// critical section — `try_send` in the I/O loop, swap in
-    /// start/stop — is pure CPU and never `.await`s.
-    recording_tx: Arc<Mutex<Option<mpsc::Sender<RecordingEvent>>>>,
+    /// Handle to the active recording writer. `None` when no
+    /// recording is active. The slot bundles the mpsc sender *and*
+    /// a shared drop counter the writer reads at finalisation — the
+    /// two must not drift apart, otherwise a back-pressured
+    /// `try_send` could go unreported and the recording would be
+    /// marked `completed` with invisible gaps (the exact failure
+    /// mode the Codex adversarial review flagged). Wrapped in
+    /// `Arc<Mutex<_>>` so the PTY I/O loop (captures a clone of the
+    /// Arc at spawn time) and the `start_recording` /
+    /// `stop_recording` public methods can both read/write it
+    /// without holding the sessions RwLock. The inner Mutex is std
+    /// (not tokio) because the critical section — `try_send` in the
+    /// I/O loop, swap in start/stop — is pure CPU and never
+    /// `.await`s.
+    recording_tx: Arc<Mutex<Option<RecordingSlot>>>,
 }
 
 pub struct SessionHub {
@@ -384,8 +391,7 @@ impl SessionHub {
         let sessions_arc = self.sessions.clone();
         let session_service_clone = self.session_service.clone();
         let scrollback_for_pty = scrollback.clone();
-        let recording_tx_arc: Arc<Mutex<Option<mpsc::Sender<RecordingEvent>>>> =
-            Arc::new(Mutex::new(None));
+        let recording_tx_arc: Arc<Mutex<Option<RecordingSlot>>> = Arc::new(Mutex::new(None));
         let recording_tx_for_pty = recording_tx_arc.clone();
         let pty_size_arc: Arc<Mutex<(u16, u16)>> = Arc::new(Mutex::new((cols, rows)));
         let pty_size_for_pty = pty_size_arc.clone();
@@ -443,14 +449,20 @@ impl SessionHub {
                         let _ = output_tx_clone.send(bytes.clone());
                         drop(sb);
                         // Recording tap: non-blocking send so the I/O loop
-                        // never stalls on a slow writer. If the channel is
-                        // full or gone, the event is silently dropped —
-                        // acceptable for a best-effort recording stream.
-                        if let Some(ref tx) = *recording_tx_for_pty
+                        // never stalls on a slow writer. A full channel is
+                        // still dropped here — the terminal cannot stall
+                        // waiting on a slow disk — but `RecordingSlot::try_send`
+                        // bumps a shared counter on every drop, and the
+                        // writer reads that counter at finalisation time
+                        // to downgrade the recording's status from
+                        // `completed` to `failed`. That replaces the
+                        // previous "silent drop → lie to the viewer"
+                        // failure mode with an observable one.
+                        if let Some(ref slot) = *recording_tx_for_pty
                             .lock()
                             .expect("recording_tx mutex poisoned")
                         {
-                            let _ = tx.try_send(RecordingEvent::Output(bytes));
+                            slot.try_send(RecordingEvent::Output(bytes));
                         }
                     }
                     Action::Output(None) => {
@@ -477,11 +489,11 @@ impl SessionHub {
                                 *guard = (cols, rows);
                             }
                         }
-                        if let Some(ref tx) = *recording_tx_for_pty
+                        if let Some(ref slot) = *recording_tx_for_pty
                             .lock()
                             .expect("recording_tx mutex poisoned")
                         {
-                            let _ = tx.try_send(RecordingEvent::Resize { cols, rows });
+                            slot.try_send(RecordingEvent::Resize { cols, rows });
                         }
                     }
                     Action::Command(None) => {
@@ -495,14 +507,14 @@ impl SessionHub {
             // the session. Uses async `send` so the writer receives the
             // Stop before the channel drops — this gives it a chance to
             // flush remaining data and mark the recording as completed.
-            // Extract the sender under the mutex first, then drop the
+            // Extract the slot under the mutex first, then drop the
             // guard before the .await — std::sync::MutexGuard is !Send.
-            let recording_tx_owned = recording_tx_for_pty
+            let recording_slot_owned = recording_tx_for_pty
                 .lock()
                 .expect("recording_tx mutex poisoned")
                 .take();
-            if let Some(tx) = recording_tx_owned {
-                let _ = tx.send(RecordingEvent::Stop).await;
+            if let Some(slot) = recording_slot_owned {
+                let _ = slot.tx.send(RecordingEvent::Stop).await;
             }
 
             // Cleanup: remove from in-memory map and close in DB.
@@ -852,13 +864,15 @@ impl SessionHub {
                 color,
             });
 
-            // Recording tap: capture the join event.
-            if let Some(ref tx) = *live
+            // Recording tap: capture the join event. Any back-pressured
+            // drop is recorded in the slot's counter so finalisation
+            // marks the recording `failed`.
+            if let Some(ref slot) = *live
                 .recording_tx
                 .lock()
                 .expect("recording_tx mutex poisoned")
             {
-                let _ = tx.try_send(RecordingEvent::ParticipantJoin {
+                slot.try_send(RecordingEvent::ParticipantJoin {
                     user_id: user_id.to_string(),
                     name,
                     role: role.as_str().to_string(),
@@ -897,13 +911,14 @@ impl SessionHub {
         if live.participants.remove(&user_id).is_some() {
             let _ = live.collab_tx.send(ServerMessage::PeerLeft { user_id });
 
-            // Recording tap: capture the leave event.
-            if let Some(ref tx) = *live
+            // Recording tap: capture the leave event. Back-pressured
+            // drops are counted so finalisation can reflect the gap.
+            if let Some(ref slot) = *live
                 .recording_tx
                 .lock()
                 .expect("recording_tx mutex poisoned")
             {
-                let _ = tx.try_send(RecordingEvent::ParticipantLeave {
+                slot.try_send(RecordingEvent::ParticipantLeave {
                     user_id: user_id.to_string(),
                 });
             }
@@ -951,13 +966,14 @@ impl SessionHub {
         hist.push_back(entry.clone());
         let _ = live.collab_tx.send(entry.clone().into());
 
-        // Recording tap: capture the chat event.
-        if let Some(ref tx) = *live
+        // Recording tap: capture the chat event. Back-pressured
+        // drops are counted so finalisation can reflect the gap.
+        if let Some(ref slot) = *live
             .recording_tx
             .lock()
             .expect("recording_tx mutex poisoned")
         {
-            let _ = tx.try_send(RecordingEvent::Chat {
+            slot.try_send(RecordingEvent::Chat {
                 user_id: entry.user_id.to_string(),
                 name: entry.name,
                 text: entry.text,
@@ -965,16 +981,19 @@ impl SessionHub {
         }
     }
 
-    /// Activate recording on a live session by installing a sender
-    /// into the shared `recording_tx` slot. The PTY I/O loop and
-    /// collab methods will start forwarding events to this sender
-    /// immediately. Returns `Err` if the session is not live or if a
-    /// recording is already active (callers must stop the existing one
-    /// first).
+    /// Activate recording on a live session by installing a
+    /// [`RecordingSlot`] (sender + drop counter) into the shared
+    /// slot. The PTY I/O loop and collab methods will start
+    /// forwarding events through `slot.try_send` immediately, which
+    /// bumps `slot.dropped` on every back-pressured drop — the
+    /// writer task reads that counter at finalisation and downgrades
+    /// the recording's status if any events were lost. Returns
+    /// `Err` if the session is not live or if a recording is
+    /// already active (callers must stop the existing one first).
     pub async fn start_recording(
         &self,
         session_id: &str,
-        recording_tx: mpsc::Sender<RecordingEvent>,
+        slot: RecordingSlot,
     ) -> std::result::Result<(), &'static str> {
         let sessions = self.sessions.read().await;
         let Some(SessionEntry::Live(live)) = sessions.get(session_id) else {
@@ -987,7 +1006,7 @@ impl SessionHub {
         if guard.is_some() {
             return Err("recording already active");
         }
-        *guard = Some(recording_tx);
+        *guard = Some(slot);
         Ok(())
     }
 
@@ -1003,7 +1022,7 @@ impl SessionHub {
         // `add_participant_and_snapshot`, `update_participant_role`,
         // …) for the duration of the channel-send back-pressure —
         // which under a slow/hung writer can be seconds.
-        let tx = {
+        let slot = {
             let sessions = self.sessions.read().await;
             let Some(SessionEntry::Live(live)) = sessions.get(session_id) else {
                 return Err("session not found or not live");
@@ -1017,10 +1036,10 @@ impl SessionHub {
             // this block.
             taken
         };
-        let Some(tx) = tx else {
+        let Some(slot) = slot else {
             return Err("no recording active");
         };
-        let _ = tx.send(RecordingEvent::Stop).await;
+        let _ = slot.tx.send(RecordingEvent::Stop).await;
         Ok(())
     }
 

--- a/crates/telepair-gateway/src/session_hub.rs
+++ b/crates/telepair-gateway/src/session_hub.rs
@@ -13,6 +13,7 @@ use telepair_control::session_service::SessionService;
 use telepair_core::error::Result;
 use telepair_core::permission::Role;
 use telepair_core::protocol::{ChatEntry, ParticipantInfo, ServerMessage};
+use telepair_core::recording::RecordingEvent;
 use telepair_core::session::CloseReason;
 
 /// Color palette for participant cursors / identifiers.
@@ -264,6 +265,23 @@ struct LiveSession {
     /// what gives the "every PeerChat is in the snapshot OR the
     /// receiver, never both" invariant.
     chat_history: Arc<Mutex<VecDeque<ChatEntry>>>,
+    /// Current PTY dimensions, kept in lockstep with the live shell.
+    /// Initialised from `PtyLaunch.{cols,rows}` and updated by the
+    /// PTY I/O loop on every `PtyCommand::Resize`. `start_recording`
+    /// reads this so the asciicast header and `recordings.{width,
+    /// height}` columns reflect the actual terminal — without it
+    /// every recording was stamped 80×24 regardless of the real
+    /// session size and playback rendered at the wrong aspect.
+    pty_size: Arc<Mutex<(u16, u16)>>,
+    /// Channel for sending recording events to the `RecordingWriter`
+    /// task. `None` when no recording is active. Wrapped in
+    /// `Arc<Mutex<_>>` so the PTY I/O loop (which captures a clone of
+    /// the Arc at spawn time) and the `start_recording` / `stop_recording`
+    /// public methods can both read/write it without holding the
+    /// sessions RwLock. The inner Mutex is std (not tokio) because the
+    /// critical section — `try_send` in the I/O loop, swap in
+    /// start/stop — is pure CPU and never `.await`s.
+    recording_tx: Arc<Mutex<Option<mpsc::Sender<RecordingEvent>>>>,
 }
 
 pub struct SessionHub {
@@ -366,6 +384,11 @@ impl SessionHub {
         let sessions_arc = self.sessions.clone();
         let session_service_clone = self.session_service.clone();
         let scrollback_for_pty = scrollback.clone();
+        let recording_tx_arc: Arc<Mutex<Option<mpsc::Sender<RecordingEvent>>>> =
+            Arc::new(Mutex::new(None));
+        let recording_tx_for_pty = recording_tx_arc.clone();
+        let pty_size_arc: Arc<Mutex<(u16, u16)>> = Arc::new(Mutex::new((cols, rows)));
+        let pty_size_for_pty = pty_size_arc.clone();
 
         // PTY I/O loop -- single task owns the PtyManager
         tokio::spawn(async move {
@@ -417,8 +440,18 @@ impl SessionHub {
                         sb.push(bytes.clone());
                         // Already a refcounted Bytes from the PTY reader;
                         // every subscriber clone is an Arc bump, not a copy.
-                        let _ = output_tx_clone.send(bytes);
+                        let _ = output_tx_clone.send(bytes.clone());
                         drop(sb);
+                        // Recording tap: non-blocking send so the I/O loop
+                        // never stalls on a slow writer. If the channel is
+                        // full or gone, the event is silently dropped —
+                        // acceptable for a best-effort recording stream.
+                        if let Some(ref tx) = *recording_tx_for_pty
+                            .lock()
+                            .expect("recording_tx mutex poisoned")
+                        {
+                            let _ = tx.try_send(RecordingEvent::Output(bytes));
+                        }
                     }
                     Action::Output(None) => {
                         tracing::info!(session = %session_id_owned, "PTY process exited");
@@ -431,12 +464,45 @@ impl SessionHub {
                     }
                     Action::Command(Some(PtyCommand::Resize(cols, rows))) => {
                         let _ = pty.resize(cols, rows);
+                        // Track the latest size so a recording started
+                        // after a resize uses the new dimensions. Skip
+                        // the write when the value is unchanged — some
+                        // emulators emit synthetic resizes on focus and
+                        // every avoided write also avoids a notify on
+                        // any future reader of `pty_size`.
+                        {
+                            let mut guard =
+                                pty_size_for_pty.lock().expect("pty_size mutex poisoned");
+                            if *guard != (cols, rows) {
+                                *guard = (cols, rows);
+                            }
+                        }
+                        if let Some(ref tx) = *recording_tx_for_pty
+                            .lock()
+                            .expect("recording_tx mutex poisoned")
+                        {
+                            let _ = tx.try_send(RecordingEvent::Resize { cols, rows });
+                        }
                     }
                     Action::Command(None) => {
                         tracing::info!(session = %session_id_owned, "all clients disconnected");
                         break;
                     }
                 }
+            }
+
+            // Stop the recording writer (if active) before tearing down
+            // the session. Uses async `send` so the writer receives the
+            // Stop before the channel drops — this gives it a chance to
+            // flush remaining data and mark the recording as completed.
+            // Extract the sender under the mutex first, then drop the
+            // guard before the .await — std::sync::MutexGuard is !Send.
+            let recording_tx_owned = recording_tx_for_pty
+                .lock()
+                .expect("recording_tx mutex poisoned")
+                .take();
+            if let Some(tx) = recording_tx_owned {
+                let _ = tx.send(RecordingEvent::Stop).await;
             }
 
             // Cleanup: remove from in-memory map and close in DB.
@@ -492,6 +558,8 @@ impl SessionHub {
             idle_since: Some(Instant::now()),
             color_counter: 0,
             chat_history: Arc::new(Mutex::new(VecDeque::with_capacity(CHAT_HISTORY_CAP))),
+            pty_size: pty_size_arc,
+            recording_tx: recording_tx_arc,
         };
         // `insert` overwrites a stale `Pending` reservation in place
         // — that is the load-bearing semantic for closing the
@@ -779,10 +847,23 @@ impl SessionHub {
             // Broadcast PeerJoined to all collab subscribers
             let _ = live.collab_tx.send(ServerMessage::PeerJoined {
                 user_id,
-                name,
+                name: name.clone(),
                 role,
                 color,
             });
+
+            // Recording tap: capture the join event.
+            if let Some(ref tx) = *live
+                .recording_tx
+                .lock()
+                .expect("recording_tx mutex poisoned")
+            {
+                let _ = tx.try_send(RecordingEvent::ParticipantJoin {
+                    user_id: user_id.to_string(),
+                    name,
+                    role: role.as_str().to_string(),
+                });
+            }
         }
         // Else: additional connection from an already-joined user — don't
         // re-broadcast PeerJoined or reassign a color; the existing
@@ -815,6 +896,17 @@ impl SessionHub {
         live.connections.remove(&user_id);
         if live.participants.remove(&user_id).is_some() {
             let _ = live.collab_tx.send(ServerMessage::PeerLeft { user_id });
+
+            // Recording tap: capture the leave event.
+            if let Some(ref tx) = *live
+                .recording_tx
+                .lock()
+                .expect("recording_tx mutex poisoned")
+            {
+                let _ = tx.try_send(RecordingEvent::ParticipantLeave {
+                    user_id: user_id.to_string(),
+                });
+            }
         }
 
         // If this was the last connection for the whole session, start
@@ -857,7 +949,123 @@ impl SessionHub {
             hist.pop_front();
         }
         hist.push_back(entry.clone());
-        let _ = live.collab_tx.send(entry.into());
+        let _ = live.collab_tx.send(entry.clone().into());
+
+        // Recording tap: capture the chat event.
+        if let Some(ref tx) = *live
+            .recording_tx
+            .lock()
+            .expect("recording_tx mutex poisoned")
+        {
+            let _ = tx.try_send(RecordingEvent::Chat {
+                user_id: entry.user_id.to_string(),
+                name: entry.name,
+                text: entry.text,
+            });
+        }
+    }
+
+    /// Activate recording on a live session by installing a sender
+    /// into the shared `recording_tx` slot. The PTY I/O loop and
+    /// collab methods will start forwarding events to this sender
+    /// immediately. Returns `Err` if the session is not live or if a
+    /// recording is already active (callers must stop the existing one
+    /// first).
+    pub async fn start_recording(
+        &self,
+        session_id: &str,
+        recording_tx: mpsc::Sender<RecordingEvent>,
+    ) -> std::result::Result<(), &'static str> {
+        let sessions = self.sessions.read().await;
+        let Some(SessionEntry::Live(live)) = sessions.get(session_id) else {
+            return Err("session not found or not live");
+        };
+        let mut guard = live
+            .recording_tx
+            .lock()
+            .expect("recording_tx mutex poisoned");
+        if guard.is_some() {
+            return Err("recording already active");
+        }
+        *guard = Some(recording_tx);
+        Ok(())
+    }
+
+    /// Deactivate recording on a live session. Takes the sender out
+    /// of the shared slot and sends `RecordingEvent::Stop` so the
+    /// writer can flush and finalize. Returns `Err` if the session is
+    /// not live or no recording is active.
+    pub async fn stop_recording(&self, session_id: &str) -> std::result::Result<(), &'static str> {
+        // Take the sender out of the slot under the read guard, then
+        // drop the guard *before* awaiting the Stop send. Holding the
+        // tokio RwLock read guard across `tx.send().await` is enough
+        // to block every concurrent writer (`stop_session`,
+        // `add_participant_and_snapshot`, `update_participant_role`,
+        // …) for the duration of the channel-send back-pressure —
+        // which under a slow/hung writer can be seconds.
+        let tx = {
+            let sessions = self.sessions.read().await;
+            let Some(SessionEntry::Live(live)) = sessions.get(session_id) else {
+                return Err("session not found or not live");
+            };
+            let taken = live
+                .recording_tx
+                .lock()
+                .expect("recording_tx mutex poisoned")
+                .take();
+            // `sessions` (the read guard) is dropped at the end of
+            // this block.
+            taken
+        };
+        let Some(tx) = tx else {
+            return Err("no recording active");
+        };
+        let _ = tx.send(RecordingEvent::Stop).await;
+        Ok(())
+    }
+
+    /// Clear the recording slot on a live session without sending a
+    /// `Stop` event. The writer task is responsible for invoking this
+    /// when it aborts due to an I/O failure — otherwise the slot
+    /// keeps the (now-dead) sender, `stop_recording` cannot detach,
+    /// and the owner cannot start a new recording for the rest of
+    /// the session's lifetime. A no-op if the session is gone or no
+    /// recording was active.
+    pub async fn clear_recording_slot(&self, session_id: &str) {
+        let sessions = self.sessions.read().await;
+        if let Some(SessionEntry::Live(live)) = sessions.get(session_id) {
+            let _ = live
+                .recording_tx
+                .lock()
+                .expect("recording_tx mutex poisoned")
+                .take();
+        }
+    }
+
+    /// Current PTY dimensions for a live session, or `None` if the
+    /// session is not live. Used by `start_recording` so the
+    /// asciicast header and the DB row reflect the actual terminal
+    /// size at the moment recording begins, instead of the original
+    /// 80×24 default the previous code hardcoded.
+    pub async fn pty_size(&self, session_id: &str) -> Option<(u16, u16)> {
+        let sessions = self.sessions.read().await;
+        let SessionEntry::Live(live) = sessions.get(session_id)? else {
+            return None;
+        };
+        let size = *live.pty_size.lock().expect("pty_size mutex poisoned");
+        Some(size)
+    }
+
+    /// Check whether a recording is currently active on a session.
+    pub async fn has_recording(&self, session_id: &str) -> bool {
+        let sessions = self.sessions.read().await;
+        let Some(SessionEntry::Live(live)) = sessions.get(session_id) else {
+            return false;
+        };
+        live.recording_tx
+            .lock()
+            .expect("recording_tx mutex poisoned")
+            .is_some()
     }
 
     /// Update a participant's role in a live session. Mutates the

--- a/crates/telepair-gateway/src/state.rs
+++ b/crates/telepair-gateway/src/state.rs
@@ -5,10 +5,12 @@ use arc_swap::ArcSwap;
 use telepair_agent::virtual_target::TargetEngine;
 use telepair_control::auth_service::{AuthService, SmtpConfig};
 use telepair_control::invite_service::InviteService;
+use telepair_control::recording_service::RecordingService;
 use telepair_control::session_service::SessionService;
 use telepair_control::user_target_service::UserTargetService;
 use telepair_core::audit::AuditSink;
 use telepair_core::auth::TokenAuthProvider;
+use telepair_core::recording::RecordingConfig;
 use telepair_core::storage::{SqliteStorage, Storage};
 
 use crate::rate_limit::{DEFAULT_REGISTER_MIN_INTERVAL, RegisterRateLimiter};
@@ -54,20 +56,23 @@ pub struct AppState {
     pub auth_service: Arc<AuthService>,
     /// Per-user virtual target CRUD and PTY resolution.
     pub user_targets: Arc<UserTargetService>,
+    /// Session recording business logic (create, share, TTL).
+    pub recording: Arc<RecordingService>,
     /// Records the instant the server started, for uptime reporting.
     pub startup: std::time::Instant,
     /// Resolved data directory path (e.g. `~/.telepair`).
     pub data_dir: PathBuf,
     /// Whether SMTP was configured at startup.
     pub smtp_configured: bool,
-    /// Per-IP rate limiter for `POST /api/auth/register`. `None` in
-    /// test fixtures (so unit tests that fire many requests back to
-    /// back aren't throttled) and in any wiring that cannot see the
+    /// Per-IP rate limiter shared by the unauthenticated auth surface:
+    /// `POST /api/auth/{register,login,verify}`. `None` in test
+    /// fixtures (so unit tests that fire many requests back to back
+    /// aren't throttled) and in any wiring that cannot see the
     /// caller's `SocketAddr` (tower oneshot, reverse proxies that
     /// don't forward ConnectInfo). Production sets this via
     /// [`AppState::new`].
-    pub register_rl: Option<Arc<RegisterRateLimiter>>,
-    /// When `true`, the rate-limit gate on `POST /api/auth/register`
+    pub auth_rl: Option<Arc<RegisterRateLimiter>>,
+    /// When `true`, the rate-limit gate on the auth endpoints
     /// reads the caller's real IP from `X-Real-IP` (preferred; set by
     /// nginx from `$remote_addr`, non-forgeable in the documented
     /// single-hop deployment) or the rightmost `X-Forwarded-For`
@@ -90,6 +95,7 @@ impl AppState {
         targets_path: Option<PathBuf>,
         smtp: Option<Arc<SmtpConfig>>,
         data_dir: PathBuf,
+        recording_config: RecordingConfig,
     ) -> Self {
         let smtp_configured = smtp.is_some();
         let auth = Arc::new(TokenAuthProvider::new(storage.clone()));
@@ -104,6 +110,7 @@ impl AppState {
         let hub = Arc::new(SessionHub::new(sessions.clone()));
         let auth_service = Arc::new(AuthService::new(storage.clone(), smtp, audit.clone()));
         let user_targets = Arc::new(UserTargetService::new(storage.clone()));
+        let recording = Arc::new(RecordingService::new(storage.clone(), recording_config));
         // Production: start the idle-session reaper so orphaned PTYs
         // don't leak when all clients disconnect. The JoinHandle is
         // intentionally detached — the task lives for the process
@@ -113,12 +120,12 @@ impl AppState {
         // `drop` (not `let _`) to silence clippy::let_underscore_future:
         // ignoring the handle detaches the task, which is what we want.
         std::mem::drop(hub.spawn_reaper(ReaperConfig::default()));
-        let register_rl = Arc::new(RegisterRateLimiter::new(DEFAULT_REGISTER_MIN_INTERVAL));
+        let auth_rl = Arc::new(RegisterRateLimiter::new(DEFAULT_REGISTER_MIN_INTERVAL));
         // Detached sweep — drops stale entries so the map can't grow
         // unbounded under signup churn. Cadence matches the throttle
         // window; `ReaperConfig`-style tunables aren't warranted for
         // a single-purpose limiter this small.
-        let sweep = Arc::clone(&register_rl);
+        let sweep = Arc::clone(&auth_rl);
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(DEFAULT_REGISTER_MIN_INTERVAL);
             // First tick fires immediately; skip it so startup doesn't
@@ -140,10 +147,11 @@ impl AppState {
             storage,
             auth_service,
             user_targets,
+            recording,
             startup: std::time::Instant::now(),
             data_dir,
             smtp_configured,
-            register_rl: Some(register_rl),
+            auth_rl: Some(auth_rl),
             trust_forwarded_headers: false,
         }
     }
@@ -166,6 +174,13 @@ impl AppState {
         let hub = Arc::new(SessionHub::new(sessions.clone()));
         let auth_service = Arc::new(AuthService::new(storage.clone(), None, audit.clone()));
         let user_targets = Arc::new(UserTargetService::new(storage.clone()));
+        let recording = Arc::new(RecordingService::new(
+            storage.clone(),
+            RecordingConfig {
+                dir: PathBuf::from("/tmp/telepair-test/recordings"),
+                ..RecordingConfig::default()
+            },
+        ));
         Self {
             auth,
             sessions,
@@ -177,12 +192,13 @@ impl AppState {
             storage,
             auth_service,
             user_targets,
+            recording,
             startup: std::time::Instant::now(),
             data_dir: PathBuf::from("/tmp/telepair-test"),
             smtp_configured: false,
             // Tests that want to exercise the limiter opt-in by
             // swapping this to `Some(...)` on the returned AppState.
-            register_rl: None,
+            auth_rl: None,
             trust_forwarded_headers: false,
         }
     }

--- a/crates/telepair-gateway/src/ws.rs
+++ b/crates/telepair-gateway/src/ws.rs
@@ -15,9 +15,11 @@ use tokio::sync::{mpsc, oneshot};
 
 use telepair_core::permission::Role;
 use telepair_core::protocol::{
-    ChatEntry, ClientMessage, ServerMessage, close_code_for, error_codes, input_denied,
+    ChatEntry, ClientMessage, RecordingStatusInfo, ServerMessage, close_code_for, error_codes,
+    input_denied,
 };
 use telepair_core::session::{CloseReason, InputMode};
+use telepair_core::storage::Storage;
 
 use crate::session_hub::{PtyCommand, PtyLaunch, SessionAttachment};
 use crate::state::AppState;
@@ -445,12 +447,21 @@ async fn handle_socket(socket: WebSocket, session_id: String, state: AppState) {
             Vec::new()
         });
 
+    let recording_status = match state.storage.find_active_recording(&session_id).await {
+        Ok(Some(rec)) => Some(RecordingStatusInfo {
+            recording_id: rec.id,
+            started_at: rec.started_at,
+        }),
+        _ => None,
+    };
+
     let state_msg = ServerMessage::SessionState {
         session: session.clone(),
         participants,
         your_role: my_role,
         your_user_id: user.id,
         chat_history,
+        recording: recording_status,
     };
     match serde_json::to_string(&state_msg) {
         Ok(json) => {

--- a/crates/telepair-gateway/tests/admin_audit_export_test.rs
+++ b/crates/telepair-gateway/tests/admin_audit_export_test.rs
@@ -10,6 +10,7 @@ use tower::ServiceExt;
 
 use telepair_agent::virtual_target::TargetEngine;
 use telepair_core::audit::{AuditEvent, AuditEventType, AuditSink};
+use telepair_core::recording::RecordingConfig;
 use telepair_core::storage::{SqliteStorage, Storage};
 use telepair_gateway::state::AppState;
 use telepair_gateway::{CorsMode, build_router_with_options};
@@ -41,6 +42,7 @@ async fn setup() -> (axum::Router, String) {
         None,
         None,
         PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let router = build_router_with_options(state, None, CorsMode::AllowAny).unwrap();
@@ -182,6 +184,7 @@ async fn export_csv_neutralizes_formula_prefixes() {
         None,
         None,
         PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let app = build_router_with_options(state, None, CorsMode::AllowAny).unwrap();
@@ -258,6 +261,7 @@ async fn export_requires_admin() {
         None,
         None,
         PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let app = build_router_with_options(state, None, CorsMode::AllowAny).unwrap();

--- a/crates/telepair-gateway/tests/admin_only_target_test.rs
+++ b/crates/telepair-gateway/tests/admin_only_target_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use telepair_agent::virtual_target::TargetEngine;
+use telepair_core::recording::RecordingConfig;
 use telepair_core::storage::{SqliteStorage, Storage};
 use telepair_gateway::state::AppState;
 use telepair_gateway::{CorsMode, build_router_with_options};
@@ -28,6 +29,7 @@ async fn setup() -> (axum::Router, String, String) {
         None,
         None,
         std::path::PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
 

--- a/crates/telepair-gateway/tests/admin_system_test.rs
+++ b/crates/telepair-gateway/tests/admin_system_test.rs
@@ -9,6 +9,7 @@ use http_body_util::BodyExt;
 use tower::ServiceExt;
 
 use telepair_agent::virtual_target::TargetEngine;
+use telepair_core::recording::RecordingConfig;
 use telepair_core::storage::{SqliteStorage, Storage};
 use telepair_gateway::state::AppState;
 use telepair_gateway::{CorsMode, build_router_with_options};
@@ -23,6 +24,7 @@ async fn setup() -> (axum::Router, String, String) {
         None,
         None,
         PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let router = build_router_with_options(state, None, CorsMode::AllowAny).unwrap();

--- a/crates/telepair-gateway/tests/admin_targets_test.rs
+++ b/crates/telepair-gateway/tests/admin_targets_test.rs
@@ -24,6 +24,7 @@ use tower::ServiceExt;
 
 use telepair_agent::virtual_target::TargetEngine;
 use telepair_core::audit::{AuditEventType, AuditFilter};
+use telepair_core::recording::RecordingConfig;
 use telepair_core::session::InputMode;
 use telepair_core::storage::{SqliteStorage, Storage};
 use telepair_gateway::session_hub::PtyLaunch;
@@ -91,6 +92,7 @@ async fn setup(
         Some(path.clone()),
         None,
         std::path::PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let router = build_router_with_options(state, None, CorsMode::AllowAny).unwrap();
@@ -302,6 +304,7 @@ async fn reload_targets_audit_event_is_recorded() {
         Some(path.clone()),
         None,
         std::path::PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let app = build_router_with_options(state, None, CorsMode::AllowAny).unwrap();
@@ -458,6 +461,7 @@ async fn reload_targets_rejects_drop_of_still_referenced_target() {
         Some(path.clone()),
         None,
         std::path::PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     state
@@ -577,6 +581,7 @@ async fn reload_targets_allows_adding_new_target_with_referenced_alive() {
         Some(path.clone()),
         None,
         std::path::PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     state
@@ -664,6 +669,7 @@ async fn reload_targets_allows_drop_when_only_stale_db_row_present() {
         Some(path.clone()),
         None,
         std::path::PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let app = build_router_with_options(state, None, CorsMode::AllowAny).unwrap();
@@ -742,6 +748,7 @@ async fn reload_targets_rejects_drop_during_create_to_attach_gap() {
         Some(path.clone()),
         None,
         std::path::PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let app = build_router_with_options(state, None, CorsMode::AllowAny).unwrap();

--- a/crates/telepair-gateway/tests/admin_users_test.rs
+++ b/crates/telepair-gateway/tests/admin_users_test.rs
@@ -20,6 +20,7 @@ use tower::ServiceExt;
 
 use telepair_agent::virtual_target::TargetEngine;
 use telepair_core::audit::{AuditEventType, AuditFilter};
+use telepair_core::recording::RecordingConfig;
 use telepair_core::storage::{SqliteStorage, Storage};
 use telepair_gateway::state::AppState;
 use telepair_gateway::{CorsMode, build_router_with_options};
@@ -56,6 +57,7 @@ async fn setup() -> (
         None,
         None,
         std::path::PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let router = build_router_with_options(state, None, CorsMode::AllowAny).unwrap();

--- a/crates/telepair-gateway/tests/admin_validate_test.rs
+++ b/crates/telepair-gateway/tests/admin_validate_test.rs
@@ -11,6 +11,7 @@ use tempfile::NamedTempFile;
 use tower::ServiceExt;
 
 use telepair_agent::virtual_target::TargetEngine;
+use telepair_core::recording::RecordingConfig;
 use telepair_core::storage::{SqliteStorage, Storage};
 use telepair_gateway::state::AppState;
 use telepair_gateway::{CorsMode, build_router_with_options};
@@ -44,6 +45,7 @@ async fn setup(yaml: &str) -> (axum::Router, String, PathBuf, NamedTempFile) {
         Some(path.clone()),
         None,
         PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let router = build_router_with_options(state, None, CorsMode::AllowAny).unwrap();
@@ -246,6 +248,7 @@ async fn validate_requires_admin() {
         None,
         None,
         PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let app = build_router_with_options(state, None, CorsMode::AllowAny).unwrap();

--- a/crates/telepair-gateway/tests/change_password_evicts_ws_test.rs
+++ b/crates/telepair-gateway/tests/change_password_evicts_ws_test.rs
@@ -29,6 +29,7 @@ use tower::ServiceExt;
 use telepair_agent::virtual_target::TargetEngine;
 use telepair_core::permission::Role;
 use telepair_core::protocol::ServerMessage;
+use telepair_core::recording::RecordingConfig;
 use telepair_core::session::InputMode;
 use telepair_core::storage::{SqliteStorage, Storage};
 use telepair_gateway::build_router;
@@ -42,6 +43,7 @@ async fn start_server() -> (String, axum::Router, AppState, Arc<SqliteStorage>) 
         None,
         None,
         std::path::PathBuf::from("/tmp/telepair-test-change-pw"),
+        RecordingConfig::default(),
     )
     .await;
     let router = build_router(state.clone());

--- a/crates/telepair-gateway/tests/register_rate_limit_test.rs
+++ b/crates/telepair-gateway/tests/register_rate_limit_test.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests build a router directly (tower `oneshot`), inject a
 //! `ConnectInfo<SocketAddr>` extension into each request, and install
-//! a short rate-limit window on `AppState.register_rl` so the throttle
+//! a short rate-limit window on `AppState.auth_rl` so the throttle
 //! fires within test time. We deliberately do *not* exercise the
 //! production `AppState::new` path here — that starts a sqlite DB and
 //! a reaper task, which would slow the test without adding coverage
@@ -25,7 +25,7 @@ use tower::ServiceExt;
 /// requests without losing the shared limiter state.
 async fn setup_with_limiter(min_interval: Duration) -> axum::Router {
     let mut state = AppState::new_test().await;
-    state.register_rl = Some(Arc::new(RegisterRateLimiter::new(min_interval)));
+    state.auth_rl = Some(Arc::new(RegisterRateLimiter::new(min_interval)));
     build_router(state)
 }
 
@@ -98,7 +98,7 @@ async fn register_from_different_ip_is_not_throttled() {
 /// Build a router with the trust-forwarded-headers flag on.
 async fn setup_trusting_proxy(min_interval: Duration) -> axum::Router {
     let mut state = AppState::new_test().await;
-    state.register_rl = Some(Arc::new(RegisterRateLimiter::new(min_interval)));
+    state.auth_rl = Some(Arc::new(RegisterRateLimiter::new(min_interval)));
     state.trust_forwarded_headers = true;
     build_router(state)
 }

--- a/crates/telepair-gateway/tests/session_enabled_gate_test.rs
+++ b/crates/telepair-gateway/tests/session_enabled_gate_test.rs
@@ -33,6 +33,7 @@ use telepair_agent::virtual_target::TargetEngine;
 use telepair_core::audit::{AuditEventType, AuditFilter};
 use telepair_core::permission::Role;
 use telepair_core::protocol::{ServerMessage, error_codes};
+use telepair_core::recording::RecordingConfig;
 use telepair_core::session::{InputMode, SessionListFilter};
 use telepair_core::storage::{SqliteStorage, Storage};
 use telepair_gateway::state::AppState;
@@ -51,6 +52,7 @@ async fn setup() -> (axum::Router, AppState, Arc<SqliteStorage>) {
         None,
         None,
         std::path::PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let router = build_router_with_options(state.clone(), None, CorsMode::AllowAny).unwrap();
@@ -198,6 +200,7 @@ async fn start_server() -> (String, AppState, Arc<SqliteStorage>) {
         None,
         None,
         std::path::PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let router = build_router(state.clone());
@@ -255,6 +258,7 @@ async fn start_server_with_router() -> (String, axum::Router, AppState, Arc<Sqli
         None,
         None,
         std::path::PathBuf::from("/tmp/telepair-test"),
+        RecordingConfig::default(),
     )
     .await;
     let router = build_router(state.clone());

--- a/crates/telepair-gateway/tests/ws_test.rs
+++ b/crates/telepair-gateway/tests/ws_test.rs
@@ -237,7 +237,7 @@ async fn ws_successful_join_receives_session_state() {
             participants,
             your_role,
             your_user_id,
-            chat_history: _,
+            ..
         }) => {
             assert_eq!(sess.id, session.id);
             assert_eq!(your_role, Role::Owner);

--- a/migrations/002_recordings.sql
+++ b/migrations/002_recordings.sql
@@ -1,0 +1,33 @@
+-- recordings: metadata for each recording
+CREATE TABLE IF NOT EXISTS recordings (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'recording',
+    file_path TEXT,
+    file_size INTEGER DEFAULT 0,
+    duration_ms INTEGER,
+    width INTEGER NOT NULL,
+    height INTEGER NOT NULL,
+    event_count INTEGER DEFAULT 0,
+    started_at TEXT NOT NULL,
+    completed_at TEXT,
+    expires_at TEXT,
+    created_by TEXT NOT NULL REFERENCES users(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_recordings_session_id ON recordings(session_id);
+CREATE INDEX IF NOT EXISTS idx_recordings_created_by ON recordings(created_by);
+CREATE INDEX IF NOT EXISTS idx_recordings_expires_at ON recordings(expires_at) WHERE expires_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_recordings_status ON recordings(status);
+
+-- recording_shares: share tokens for recording access
+CREATE TABLE IF NOT EXISTS recording_shares (
+    token_sha256 TEXT PRIMARY KEY,
+    recording_id TEXT NOT NULL REFERENCES recordings(id) ON DELETE CASCADE,
+    max_uses INTEGER DEFAULT 0,
+    used_count INTEGER DEFAULT 0,
+    expires_at TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_recording_shares_recording_id ON recording_shares(recording_id);

--- a/web/e2e/recording.spec.ts
+++ b/web/e2e/recording.spec.ts
@@ -1,0 +1,250 @@
+import { test, expect } from '@playwright/test';
+import {
+  getAdminToken,
+  gotoSession,
+  login,
+  typeInTerminal,
+  waitForTerminal,
+} from './helpers';
+
+// These tests run serially and depend on each other's side effects:
+// test (1) asserts the empty state before any recording exists, then
+// tests (2)-(4) create + stop recordings that tests (5)-(6) consume.
+// Playwright's `.describe.serial` stops the block on the first failure,
+// which keeps the later tests from running against a corrupted list
+// view rather than piling on cascading failures.
+test.describe.serial('Recording feature', () => {
+  test('recordings page shows empty state before any recording exists', async ({ page }) => {
+    await login(page);
+    await page.goto('/recordings');
+
+    await expect(page.getByRole('heading', { name: 'Recordings' })).toBeVisible();
+    await expect(page.getByText('No recordings found')).toBeVisible();
+    await expect(page.getByText(/Start a session and click/)).toBeVisible();
+  });
+
+  test('session owner sees REC indicator + Stop button while a recording is active', async ({
+    page,
+    request,
+  }) => {
+    const sessionId = await gotoSession(page);
+    await waitForTerminal(page);
+    const token = getAdminToken();
+
+    // Driving recording via the REST API keeps the test honest about
+    // what the UI is wired to react to (the RecordingStarted WS frame),
+    // instead of poking Solid signals directly.
+    const start = await request.post(`/api/sessions/${sessionId}/recording/start`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(start.ok()).toBe(true);
+
+    const indicator = page.locator('.rec-indicator');
+    await expect(indicator).toBeVisible({ timeout: 5_000 });
+    await expect(indicator.locator('.rec-label')).toHaveText('REC');
+    await expect(page.getByRole('button', { name: 'Stop recording' })).toBeVisible();
+
+    // Generate a small amount of PTY output so the writer flushes a
+    // non-trivial .cast file. The player test later relies on this.
+    await typeInTerminal(page, 'echo hello-recording');
+    await page.waitForTimeout(300);
+
+    const stop = await request.post(`/api/sessions/${sessionId}/recording/stop`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(stop.ok()).toBe(true);
+
+    await expect(indicator).not.toBeVisible({ timeout: 5_000 });
+    // Share Rec button only appears after the recording has finalised —
+    // it's bound to `recordingId() && !isRecording()` in Session.tsx.
+    await expect(page.getByRole('button', { name: 'Share Rec' })).toBeVisible();
+  });
+
+  test('owner can open the Share Recording dialog from the session topbar', async ({
+    page,
+    request,
+  }) => {
+    // Fresh session + recording so the dialog has its own context; the
+    // per-test page resets auth state anyway, and we don't want to rely
+    // on the session ID from the previous test bleeding through.
+    const sessionId = await gotoSession(page);
+    await waitForTerminal(page);
+    const token = getAdminToken();
+
+    const start = await request.post(`/api/sessions/${sessionId}/recording/start`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(start.ok()).toBe(true);
+    await page.waitForTimeout(200);
+    const stop = await request.post(`/api/sessions/${sessionId}/recording/stop`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(stop.ok()).toBe(true);
+
+    await expect(page.getByRole('button', { name: 'Share Rec' })).toBeVisible({ timeout: 5_000 });
+    await page.getByRole('button', { name: 'Share Rec' }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'Share recording' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: 'Share Recording' })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: /Create Share Link/ })).toBeVisible();
+    await expect(dialog.getByText('No share links yet.')).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Close' }).click();
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test('recordings list shows completed recordings with a working status filter', async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto('/recordings');
+
+    const firstCard = page.locator('.recording-card').first();
+    await expect(firstCard).toBeVisible({ timeout: 5_000 });
+
+    // At least one row finalised to "completed" from the earlier tests.
+    const completedCards = page.locator('.recording-card[data-status="completed"]');
+    expect(await completedCards.count()).toBeGreaterThan(0);
+    await expect(completedCards.first().locator('.rec-badge.badge-completed')).toHaveText(
+      'Completed',
+    );
+
+    // Filter tab: "Recording" (no live recordings at this point) must
+    // flip the list to its empty-for-filter state without erasing the
+    // tab bar.
+    await page.getByRole('tab', { name: 'Recording' }).click();
+    await expect(page.getByText(/No recordings with status "recording"/)).toBeVisible();
+
+    // Back to "Completed" — the same card(s) should reappear.
+    await page.getByRole('tab', { name: 'Completed' }).click();
+    await expect(page.locator('.recording-card[data-status="completed"]').first()).toBeVisible();
+  });
+
+  test('clicking Play on a recording navigates to the player and renders controls', async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto('/recordings');
+
+    const card = page.locator('.recording-card[data-status="completed"]').first();
+    await expect(card).toBeVisible({ timeout: 5_000 });
+    const recId = (await card.locator('.rec-id').innerText()).trim();
+
+    await card.getByRole('button', { name: /Play/ }).click();
+    await page.waitForURL(new RegExp(`/recordings/${recId}$`));
+
+    // Player page: terminal container, metadata panel, and the
+    // playback controls bar should all mount once the .cast fetch
+    // completes. The progress "slider" role comes from
+    // PlaybackControls.tsx's aria-labelled div.
+    await expect(page.locator('.terminal-container')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('heading', { name: 'Recording Info' })).toBeVisible();
+    await expect(page.locator('.pb-controls')).toBeVisible();
+    await expect(page.getByRole('slider', { name: 'Seek' })).toBeVisible();
+    // Play/Pause button — starts in the "Play" label state because the
+    // player does not auto-play.
+    await expect(page.getByRole('button', { name: 'Play' })).toBeVisible();
+  });
+
+  test('anonymous share link plays back without an account', async ({
+    page,
+    request,
+    browser,
+  }) => {
+    // Spin up a fresh session + recording so we can mint a share for
+    // this specific run rather than hunting for an existing one.
+    const sessionId = await gotoSession(page);
+    await waitForTerminal(page);
+    const token = getAdminToken();
+
+    expect(
+      (await request.post(`/api/sessions/${sessionId}/recording/start`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })).ok(),
+    ).toBe(true);
+    await typeInTerminal(page, 'echo anon-share');
+    await page.waitForTimeout(300);
+    expect(
+      (await request.post(`/api/sessions/${sessionId}/recording/stop`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })).ok(),
+    ).toBe(true);
+
+    // Pull the recording id from the list endpoint — easier than
+    // fishing it out of the WS frame.
+    const list = await request.get('/api/recordings', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(list.ok()).toBe(true);
+    const rows = (await list.json()) as Array<{ id: string; session_id: string }>;
+    const rec = rows.find((r) => r.session_id === sessionId);
+    expect(rec, 'recording row for the session').toBeTruthy();
+    const recordingId = rec!.id;
+
+    const mint = await request.post(`/api/recordings/${recordingId}/shares`, {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: { max_uses: 0 },
+    });
+    expect(mint.ok()).toBe(true);
+    const { token: shareToken } = (await mint.json()) as { token: string };
+
+    // Open the share URL in a fresh, unauthenticated context — this
+    // exercises both the `/recordings/:id/play` route and the
+    // AuthGuard bypass that anonymous viewers depend on.
+    const anon = await browser.newContext();
+    const anonPage = await anon.newPage();
+    await anonPage.goto(
+      `/recordings/${recordingId}/play?token=${encodeURIComponent(shareToken)}`,
+    );
+    await expect(anonPage.locator('.terminal-container')).toBeVisible({ timeout: 10_000 });
+    await expect(anonPage.getByRole('button', { name: 'Play' })).toBeVisible();
+    // Critically: an anonymous viewer must NOT have been bounced to
+    // /login by the AuthGuard before the player mounted.
+    expect(anonPage.url()).not.toContain('/login');
+    await anon.close();
+  });
+
+  test('revoking a share token blocks subsequent playback', async ({ request }) => {
+    const token = getAdminToken();
+    // Reuse one of the recordings completed by earlier tests so we
+    // can keep this test independent of any specific session id.
+    const list = await request.get('/api/recordings', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const rows = (await list.json()) as Array<{ id: string }>;
+    expect(rows.length, 'at least one recording from prior tests').toBeGreaterThan(0);
+    const recordingId = rows[0].id;
+
+    const mint = await request.post(`/api/recordings/${recordingId}/shares`, {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: { max_uses: 0 },
+    });
+    expect(mint.ok()).toBe(true);
+    const { token: shareToken, share } = (await mint.json()) as {
+      token: string;
+      share: { token_sha256: string };
+    };
+
+    // Pre-revoke: anonymous fetch with the token must work.
+    const ok = await request.get(
+      `/api/recordings/${recordingId}/data?token=${encodeURIComponent(shareToken)}`,
+    );
+    expect(ok.ok()).toBe(true);
+
+    // Revoke via the SHA-256 path (the URL no longer carries the
+    // raw secret) and confirm the server actually deletes the row.
+    const revoke = await request.delete(
+      `/api/recordings/${recordingId}/shares/${share.token_sha256}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    expect(revoke.status()).toBe(204);
+
+    // Post-revoke: anonymous fetch with the same token must fail.
+    const denied = await request.get(
+      `/api/recordings/${recordingId}/data?token=${encodeURIComponent(shareToken)}`,
+    );
+    expect(denied.ok()).toBe(false);
+    expect([400, 401, 403, 404]).toContain(denied.status());
+  });
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "telepair-web",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "telepair-web",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "dependencies": {
         "@solid-primitives/i18n": "^2.2.1",
         "@solidjs/router": "^0.16.1",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "telepair-web",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "telepair-web",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@solid-primitives/i18n": "^2.2.1",
         "@solidjs/router": "^0.16.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "telepair-web",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -46,6 +46,12 @@ export default defineConfig({
       // without PATH/HOME and silently fail before binding the port.
       ...(process.env as Record<string, string>),
       TELEPAIR_DATA_DIR: E2E_DATA_DIR,
+      // Master switch for session recording. Recording is still opt-in
+      // per session (via the recording API), but the server ignores
+      // those calls entirely when this is false — leaving the feature
+      // untestable end-to-end. Flipping it on is safe for non-recording
+      // tests since no session auto-records without an explicit start.
+      TELEPAIR_RECORDING_ENABLED: 'true',
     },
   },
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,8 @@ import AdminUsers from './pages/AdminUsers';
 import AdminAudit from './pages/AdminAudit';
 import AdminSystem from './pages/AdminSystem';
 import ChangePassword from './pages/ChangePassword';
+import Recordings from './pages/Recordings';
+import RecordingPlayer from './pages/RecordingPlayer';
 import ToastContainer from './components/Toast';
 
 function AuthGuard(props: { children: JSX.Element }) {
@@ -74,6 +76,16 @@ export default function App() {
         <Route path="/" component={() => <AuthGuard><Dashboard /></AuthGuard>} />
         <Route path="/session/:id" component={() => <AuthGuard><Session /></AuthGuard>} />
         <Route path="/change-password" component={() => <AuthGuard><ChangePassword /></AuthGuard>} />
+        <Route path="/recordings" component={() => <AuthGuard><Recordings /></AuthGuard>} />
+        <Route path="/recordings/:id" component={() => <AuthGuard><RecordingPlayer /></AuthGuard>} />
+        {/*
+          Anonymous share-token playback. Lives outside AuthGuard so a
+          recipient with a `?token=...` query parameter can open the
+          link without an account; the player component itself reads
+          the token and uses the public `/recordings/:id/data?token=`
+          endpoint instead of the authed metadata endpoint.
+        */}
+        <Route path="/recordings/:id/play" component={RecordingPlayer} />
         <Route
           path="/admin/targets"
           component={() => (

--- a/web/src/components/CollabSidebar.tsx
+++ b/web/src/components/CollabSidebar.tsx
@@ -1,0 +1,192 @@
+// web/src/components/CollabSidebar.tsx
+import { For, Show, createMemo } from 'solid-js';
+import type { JSX } from 'solid-js';
+import type { ParticipantPayload, ChatPayload } from '../lib/playback';
+
+export interface CollabChatMessage extends ChatPayload {
+  time: number;
+}
+
+export interface CollabSidebarProps {
+  participants: ParticipantPayload[];
+  chatMessages: CollabChatMessage[];
+  /** Current playback position in seconds. Chat messages at time > currentTime are hidden. */
+  currentTime: number;
+}
+
+/** Deterministic color from a user_id string. */
+function nameColor(userId: string): string {
+  const colors = [
+    '#58a6ff', '#3fb950', '#d2a8ff', '#ffa657',
+    '#f78166', '#79c0ff', '#a5d6ff', '#7ee787',
+  ];
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) >>> 0;
+  }
+  return colors[hash % colors.length];
+}
+
+export default function CollabSidebar(props: CollabSidebarProps): JSX.Element {
+  const visibleMessages = createMemo(() =>
+    props.chatMessages.filter((m) => m.time <= props.currentTime),
+  );
+
+  return (
+    <div class="collab-sidebar">
+      {/* Participants section */}
+      <div class="collab-section">
+        <h3 class="collab-section-title">Participants</h3>
+        <Show
+          when={props.participants.length > 0}
+          fallback={<p class="collab-empty">No participants yet</p>}
+        >
+          <ul class="collab-participant-list">
+            <For each={props.participants}>
+              {(p) => (
+                <li class="collab-participant">
+                  <span class="collab-presence-dot" />
+                  <span class="collab-participant-name" style={{ color: nameColor(p.user_id) }}>
+                    {p.name}
+                  </span>
+                  <Show when={p.role}>
+                    <span class="collab-participant-role">{p.role}</span>
+                  </Show>
+                </li>
+              )}
+            </For>
+          </ul>
+        </Show>
+      </div>
+
+      {/* Chat section */}
+      <div class="collab-section collab-chat-section">
+        <h3 class="collab-section-title">Chat</h3>
+        <Show
+          when={visibleMessages().length > 0}
+          fallback={<p class="collab-empty">No messages yet</p>}
+        >
+          <div class="collab-chat-list">
+            <For each={visibleMessages()}>
+              {(m) => (
+                <div class="collab-chat-entry">
+                  <span class="collab-chat-name" style={{ color: nameColor(m.user_id) }}>
+                    {m.name}
+                  </span>
+                  <span class="collab-chat-text">{m.text}</span>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+
+      <style>{`
+        .collab-sidebar {
+          width: 220px;
+          min-width: 220px;
+          border-left: 1px solid var(--border, #30363d);
+          background: var(--bg-secondary, #161b22);
+          display: flex;
+          flex-direction: column;
+          overflow: hidden;
+          font-size: 13px;
+        }
+
+        .collab-section {
+          padding: 12px;
+          border-bottom: 1px solid var(--border, #30363d);
+        }
+
+        .collab-chat-section {
+          flex: 1;
+          border-bottom: none;
+          min-height: 0;
+          display: flex;
+          flex-direction: column;
+        }
+
+        .collab-section-title {
+          font-size: 11px;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.06em;
+          color: var(--text-secondary, #8b949e);
+          margin: 0 0 8px;
+        }
+
+        .collab-empty {
+          color: var(--text-secondary, #8b949e);
+          font-size: 12px;
+          margin: 0;
+          font-style: italic;
+        }
+
+        .collab-participant-list {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+        }
+
+        .collab-participant {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+        }
+
+        .collab-presence-dot {
+          width: 7px;
+          height: 7px;
+          border-radius: 50%;
+          background: #3fb950;
+          flex-shrink: 0;
+        }
+
+        .collab-participant-name {
+          font-weight: 500;
+          flex: 1;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .collab-participant-role {
+          font-size: 10px;
+          color: var(--text-secondary, #8b949e);
+          text-transform: capitalize;
+          flex-shrink: 0;
+        }
+
+        .collab-chat-list {
+          flex: 1;
+          overflow-y: auto;
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+          padding-right: 2px;
+        }
+
+        .collab-chat-entry {
+          display: flex;
+          flex-direction: column;
+          gap: 2px;
+          word-break: break-word;
+        }
+
+        .collab-chat-name {
+          font-weight: 600;
+          font-size: 12px;
+        }
+
+        .collab-chat-text {
+          color: var(--text-primary, #c9d1d9);
+          font-size: 12px;
+          line-height: 1.4;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/web/src/components/EventTimeline.tsx
+++ b/web/src/components/EventTimeline.tsx
@@ -1,0 +1,86 @@
+// web/src/components/EventTimeline.tsx
+import { For, Show, createMemo } from 'solid-js';
+import type { JSX } from 'solid-js';
+import type { CastEvent } from '../lib/playback';
+
+export interface EventTimelineProps {
+  /** All parsed events from the cast. Only non-output events are rendered. */
+  events: CastEvent[];
+  /** Total duration of the recording in seconds. */
+  duration: number;
+}
+
+/** Color for each non-output event type. */
+function markerColor(type: string): string {
+  switch (type) {
+    case 'r': return '#d2a8ff'; // resize — yellow-ish purple
+    case 'j': return '#3fb950'; // join — green
+    case 'l': return '#f78166'; // leave — red
+    case 'c': return '#58a6ff'; // chat — blue
+    default:  return '#8b949e'; // unknown — muted
+  }
+}
+
+/** Tooltip label for each event type. */
+function markerLabel(type: string): string {
+  switch (type) {
+    case 'r': return 'Resize';
+    case 'j': return 'Participant joined';
+    case 'l': return 'Participant left';
+    case 'c': return 'Chat message';
+    default:  return `Event (${type})`;
+  }
+}
+
+export default function EventTimeline(props: EventTimelineProps): JSX.Element {
+  // Only render non-output events. Skip type 'o' (terminal output).
+  const markers = createMemo(() => {
+    const d = props.duration;
+    if (d <= 0) return [];
+    return props.events
+      .filter((e) => e.type !== 'o')
+      .map((e) => ({
+        ...e,
+        pct: Math.min(100, Math.max(0, (e.time / d) * 100)),
+        color: markerColor(e.type),
+        label: markerLabel(e.type),
+      }));
+  });
+
+  return (
+    <Show when={markers().length > 0}>
+      <div class="evt-timeline" aria-hidden="true">
+        <For each={markers()}>
+          {(m) => (
+            <div
+              class="evt-marker"
+              title={`${m.label} at ${m.time.toFixed(1)}s`}
+              style={{
+                left: `${m.pct}%`,
+                background: m.color,
+              }}
+            />
+          )}
+        </For>
+
+        <style>{`
+          .evt-timeline {
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+          }
+
+          .evt-marker {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            width: 2px;
+            transform: translateX(-50%);
+            opacity: 0.75;
+            border-radius: 1px;
+          }
+        `}</style>
+      </div>
+    </Show>
+  );
+}

--- a/web/src/components/PlaybackControls.tsx
+++ b/web/src/components/PlaybackControls.tsx
@@ -1,0 +1,249 @@
+// web/src/components/PlaybackControls.tsx
+import { Show, For } from 'solid-js';
+import type { JSX } from 'solid-js';
+
+export interface PlaybackControlsProps {
+  /** Current playback position in seconds. */
+  currentTime: number;
+  /** Total duration in seconds. */
+  duration: number;
+  /** Whether playback is active. */
+  isPlaying: boolean;
+  /** Current speed multiplier. */
+  speed: number;
+  /** Whether the controls are disabled (e.g. still loading). */
+  disabled?: boolean;
+
+  onPlayPause: () => void;
+  /** Called with a seek position in seconds. */
+  onSeek: (seconds: number) => void;
+  onSpeedChange: (speed: number) => void;
+  onFullscreen?: () => void;
+}
+
+const SPEED_OPTIONS = [0.5, 1, 2, 4];
+
+/** Format seconds as `mm:ss` (or `h:mm:ss` for long recordings). */
+function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) seconds = 0;
+  const s = Math.floor(seconds);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const mm = String(m).padStart(2, '0');
+  const ss = String(sec).padStart(2, '0');
+  if (h > 0) return `${h}:${mm}:${ss}`;
+  return `${mm}:${ss}`;
+}
+
+export default function PlaybackControls(props: PlaybackControlsProps): JSX.Element {
+  const progress = () => {
+    const d = props.duration;
+    if (!d || d <= 0) return 0;
+    return Math.min(1, props.currentTime / d) * 100;
+  };
+
+  function handleProgressClick(e: MouseEvent) {
+    if (props.disabled) return;
+    const bar = e.currentTarget as HTMLDivElement;
+    const rect = bar.getBoundingClientRect();
+    const ratio = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    props.onSeek(ratio * props.duration);
+  }
+
+  return (
+    <div class="pb-controls">
+      {/* Progress bar */}
+      <div
+        class="pb-progress-track"
+        role="slider"
+        aria-label="Seek"
+        aria-valuemin={0}
+        aria-valuemax={props.duration}
+        aria-valuenow={props.currentTime}
+        tabIndex={props.disabled ? -1 : 0}
+        onClick={handleProgressClick}
+        onKeyDown={(e) => {
+          if (props.disabled) return;
+          const step = 5;
+          if (e.key === 'ArrowRight') props.onSeek(Math.min(props.currentTime + step, props.duration));
+          if (e.key === 'ArrowLeft') props.onSeek(Math.max(props.currentTime - step, 0));
+        }}
+      >
+        <div class="pb-progress-fill" style={{ width: `${progress()}%` }} />
+        <div class="pb-progress-thumb" style={{ left: `${progress()}%` }} />
+      </div>
+
+      {/* Bottom control row */}
+      <div class="pb-row">
+        {/* Play/Pause */}
+        <button
+          type="button"
+          class="pb-play-btn"
+          aria-label={props.isPlaying ? 'Pause' : 'Play'}
+          disabled={props.disabled}
+          onClick={props.onPlayPause}
+        >
+          {props.isPlaying ? '⏸' : '▶'}
+        </button>
+
+        {/* Time display */}
+        <span class="pb-time">
+          {formatTime(props.currentTime)}
+          <span class="pb-time-sep"> / </span>
+          {formatTime(props.duration)}
+        </span>
+
+        {/* Spacer */}
+        <div class="pb-spacer" />
+
+        {/* Speed selector */}
+        <div class="pb-speeds" role="group" aria-label="Playback speed">
+          <For each={SPEED_OPTIONS}>
+            {(s) => (
+              <button
+                type="button"
+                class="pb-speed-btn"
+                aria-pressed={props.speed === s}
+                disabled={props.disabled}
+                onClick={() => props.onSpeedChange(s)}
+              >
+                {s}x
+              </button>
+            )}
+          </For>
+        </div>
+
+        {/* Fullscreen */}
+        <Show when={props.onFullscreen}>
+          <button
+            type="button"
+            class="pb-fullscreen-btn"
+            aria-label="Fullscreen"
+            disabled={props.disabled}
+            onClick={props.onFullscreen}
+          >
+            ⛶
+          </button>
+        </Show>
+      </div>
+
+      <style>{`
+        .pb-controls {
+          background: #111;
+          border-top: 1px solid #2a2a2a;
+          padding: 8px 12px 10px;
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+          user-select: none;
+        }
+
+        /* Progress track */
+        .pb-progress-track {
+          position: relative;
+          height: 4px;
+          background: #333;
+          border-radius: 2px;
+          cursor: pointer;
+          outline: none;
+          margin: 4px 0;
+        }
+        .pb-progress-track:focus-visible {
+          outline: 2px solid var(--accent, #58a6ff);
+          outline-offset: 2px;
+        }
+        .pb-progress-track:hover .pb-progress-thumb {
+          opacity: 1;
+          transform: translate(-50%, -50%) scale(1);
+        }
+        .pb-progress-fill {
+          position: absolute;
+          left: 0; top: 0; bottom: 0;
+          background: var(--accent, #58a6ff);
+          border-radius: 2px;
+          pointer-events: none;
+          transition: width 0.1s linear;
+        }
+        .pb-progress-thumb {
+          position: absolute;
+          top: 50%;
+          width: 12px;
+          height: 12px;
+          background: #fff;
+          border-radius: 50%;
+          transform: translate(-50%, -50%) scale(0.7);
+          opacity: 0;
+          pointer-events: none;
+          transition: opacity 0.15s, transform 0.15s;
+        }
+
+        /* Bottom row */
+        .pb-row {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+        }
+        .pb-spacer { flex: 1; }
+
+        .pb-play-btn {
+          background: transparent;
+          border: none;
+          color: #fff;
+          font-size: 18px;
+          line-height: 1;
+          padding: 2px 6px;
+          cursor: pointer;
+          border-radius: 4px;
+          transition: background 0.15s;
+        }
+        .pb-play-btn:hover:not(:disabled) { background: rgba(255,255,255,0.1); }
+        .pb-play-btn:disabled { opacity: 0.4; cursor: default; }
+
+        .pb-time {
+          font-family: var(--font-mono, monospace);
+          font-size: 13px;
+          color: #ccc;
+          white-space: nowrap;
+        }
+        .pb-time-sep { color: #555; }
+
+        .pb-speeds {
+          display: flex;
+          gap: 2px;
+        }
+        .pb-speed-btn {
+          background: transparent;
+          border: 1px solid #444;
+          color: #aaa;
+          font-size: 12px;
+          padding: 3px 8px;
+          border-radius: 4px;
+          cursor: pointer;
+          transition: all 0.15s;
+        }
+        .pb-speed-btn:hover:not(:disabled) { border-color: var(--accent, #58a6ff); color: #fff; }
+        .pb-speed-btn:disabled { opacity: 0.4; cursor: default; }
+        .pb-speed-btn[aria-pressed='true'] {
+          background: var(--accent, #58a6ff);
+          border-color: var(--accent, #58a6ff);
+          color: #000;
+          font-weight: 600;
+        }
+
+        .pb-fullscreen-btn {
+          background: transparent;
+          border: none;
+          color: #aaa;
+          font-size: 16px;
+          padding: 2px 6px;
+          cursor: pointer;
+          border-radius: 4px;
+          transition: background 0.15s, color 0.15s;
+        }
+        .pb-fullscreen-btn:hover:not(:disabled) { background: rgba(255,255,255,0.1); color: #fff; }
+        .pb-fullscreen-btn:disabled { opacity: 0.4; cursor: default; }
+      `}</style>
+    </div>
+  );
+}

--- a/web/src/components/RecordingIndicator.tsx
+++ b/web/src/components/RecordingIndicator.tsx
@@ -1,0 +1,80 @@
+// web/src/components/RecordingIndicator.tsx
+import { Show } from 'solid-js';
+import type { JSX } from 'solid-js';
+
+export interface RecordingIndicatorProps {
+  /** Whether a recording is currently active. */
+  isRecording: boolean;
+  /** Whether the current user is the session owner (shows Stop button). */
+  isOwner: boolean;
+  /** Called when the owner clicks Stop. */
+  onStop: () => void;
+}
+
+export default function RecordingIndicator(props: RecordingIndicatorProps): JSX.Element {
+  return (
+    <Show when={props.isRecording}>
+      <div class="rec-indicator" role="status" aria-label="Recording in progress">
+        <span class="rec-dot" aria-hidden="true" />
+        <span class="rec-label">REC</span>
+        <Show when={props.isOwner}>
+          <button type="button" class="rec-stop-btn" onClick={props.onStop} aria-label="Stop recording">
+            Stop
+          </button>
+        </Show>
+      </div>
+
+      <style>{`
+        .rec-indicator {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 3px 8px;
+          border-radius: 12px;
+          background: rgba(248, 81, 73, 0.12);
+          border: 1px solid rgba(248, 81, 73, 0.4);
+        }
+
+        .rec-dot {
+          width: 8px;
+          height: 8px;
+          border-radius: 50%;
+          background: #f85149;
+          animation: rec-pulse 1.2s ease-in-out infinite;
+          flex-shrink: 0;
+        }
+
+        @keyframes rec-pulse {
+          0%, 100% { opacity: 1; }
+          50%       { opacity: 0.3; }
+        }
+
+        .rec-label {
+          font-size: 11px;
+          font-weight: 700;
+          letter-spacing: 0.08em;
+          color: #f85149;
+        }
+
+        .rec-stop-btn {
+          font-size: 11px;
+          font-weight: 600;
+          padding: 1px 7px;
+          border-radius: 8px;
+          border: 1px solid rgba(248, 81, 73, 0.5);
+          background: transparent;
+          color: #f85149;
+          cursor: pointer;
+          transition: background 0.15s, color 0.15s;
+          line-height: 1.4;
+        }
+
+        .rec-stop-btn:hover {
+          background: #f85149;
+          color: #fff;
+          border-color: #f85149;
+        }
+      `}</style>
+    </Show>
+  );
+}

--- a/web/src/components/ShareRecordingDialog.tsx
+++ b/web/src/components/ShareRecordingDialog.tsx
@@ -1,0 +1,415 @@
+// web/src/components/ShareRecordingDialog.tsx
+import { createSignal, onMount, For, Show } from 'solid-js';
+import type { JSX } from 'solid-js';
+import { api, errorMessage } from '../lib/api';
+import { formatDate } from '../lib/format';
+import type { RecordingShare } from '../lib/protocol';
+
+const SHARE_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+};
+
+export interface ShareRecordingDialogProps {
+  recordingId: string;
+  onClose: () => void;
+}
+
+export default function ShareRecordingDialog(props: ShareRecordingDialogProps): JSX.Element {
+  const [shares, setShares] = createSignal<RecordingShare[]>([]);
+  const [loading, setLoading] = createSignal(true);
+  const [error, setError] = createSignal('');
+  const [creating, setCreating] = createSignal(false);
+  const [newToken, setNewToken] = createSignal('');
+  const [copyLabel, setCopyLabel] = createSignal('Copy');
+  const [revokingSet, setRevokingSet] = createSignal<Set<string>>(new Set());
+
+  onMount(async () => {
+    await loadShares();
+  });
+
+  async function loadShares() {
+    setLoading(true);
+    setError('');
+    try {
+      const result = await api.listRecordingShares(props.recordingId);
+      setShares(result);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleCreate() {
+    setCreating(true);
+    setError('');
+    setNewToken('');
+    try {
+      const share = await api.createRecordingShare(props.recordingId);
+      // Construct the shareable URL using the plaintext token
+      const url = `${window.location.origin}/recordings/${props.recordingId}/play?token=${encodeURIComponent(share.token)}`;
+      setNewToken(url);
+      // Reload the list so the new entry appears
+      await loadShares();
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleRevoke(tokenSha256: string) {
+    setRevokingSet((prev) => new Set([...prev, tokenSha256]));
+    setError('');
+    try {
+      await api.deleteRecordingShare(props.recordingId, tokenSha256);
+      setShares((prev) => prev.filter((s) => s.token_sha256 !== tokenSha256));
+      // Clear newToken if user revokes the just-created share (sha matches prefix)
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setRevokingSet((prev) => {
+        const next = new Set(prev);
+        next.delete(tokenSha256);
+        return next;
+      });
+    }
+  }
+
+  function handleCopy() {
+    const token = newToken();
+    if (!token) return;
+    navigator.clipboard.writeText(token).then(() => {
+      setCopyLabel('Copied!');
+      setTimeout(() => setCopyLabel('Copy'), 2000);
+    }).catch(() => {
+      setCopyLabel('Copy');
+    });
+  }
+
+  return (
+    <div class="srd-overlay" onClick={(e) => { if (e.target === e.currentTarget) props.onClose(); }}>
+      <div class="srd-modal" role="dialog" aria-modal="true" aria-label="Share recording">
+        <div class="srd-header">
+          <h2 class="srd-title">Share Recording</h2>
+          <button type="button" class="srd-close" aria-label="Close" onClick={props.onClose}>
+            ✕
+          </button>
+        </div>
+
+        <div class="srd-body">
+          <Show when={error()}>
+            <p class="srd-error">{error()}</p>
+          </Show>
+
+          {/* Create new share link */}
+          <div class="srd-create-row">
+            <button
+              type="button"
+              class="srd-create-btn"
+              onClick={handleCreate}
+              disabled={creating()}
+            >
+              {creating() ? 'Creating…' : '+ Create Share Link'}
+            </button>
+          </div>
+
+          {/* Newly created token URL */}
+          <Show when={newToken()}>
+            <div class="srd-token-box">
+              <p class="srd-token-hint">Share this link (token shown only once):</p>
+              <div class="srd-token-row">
+                <input
+                  class="srd-token-input"
+                  type="text"
+                  readOnly
+                  value={newToken()}
+                  onFocus={(e) => e.currentTarget.select()}
+                  aria-label="Share link"
+                />
+                <button type="button" class="srd-copy-btn" onClick={handleCopy}>
+                  {copyLabel()}
+                </button>
+              </div>
+            </div>
+          </Show>
+
+          {/* Existing shares */}
+          <div class="srd-shares-section">
+            <h3 class="srd-section-title">Existing Links</h3>
+
+            <Show when={loading()}>
+              <p class="srd-muted">Loading…</p>
+            </Show>
+
+            <Show when={!loading() && shares().length === 0}>
+              <p class="srd-muted">No share links yet.</p>
+            </Show>
+
+            <Show when={!loading() && shares().length > 0}>
+              <ul class="srd-share-list">
+                <For each={shares()}>
+                  {(share) => (
+                    <li class="srd-share-item">
+                      <div class="srd-share-info">
+                        <span class="srd-share-prefix mono">…{share.token_sha256.slice(-8)}</span>
+                        <span class="srd-share-meta">
+                          Uses: {share.used_count} / {share.max_uses}
+                        </span>
+                        <Show when={share.expires_at}>
+                          <span class="srd-share-expiry">
+                            Expires {formatDate(share.expires_at!, SHARE_DATE_OPTIONS)}
+                          </span>
+                        </Show>
+                        <span class="srd-share-created">
+                          Created {formatDate(share.created_at, SHARE_DATE_OPTIONS)}
+                        </span>
+                      </div>
+                      <button
+                        type="button"
+                        class="srd-revoke-btn"
+                        disabled={revokingSet().has(share.token_sha256)}
+                        onClick={() => handleRevoke(share.token_sha256)}
+                      >
+                        {revokingSet().has(share.token_sha256) ? 'Revoking…' : 'Revoke'}
+                      </button>
+                    </li>
+                  )}
+                </For>
+              </ul>
+            </Show>
+          </div>
+        </div>
+      </div>
+
+      <style>{`
+        .srd-overlay {
+          position: fixed;
+          inset: 0;
+          background: rgba(0, 0, 0, 0.6);
+          z-index: 50;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 16px;
+        }
+
+        .srd-modal {
+          background: var(--bg-secondary, #161b22);
+          border: 1px solid var(--border, #30363d);
+          border-radius: 10px;
+          width: 100%;
+          max-width: 520px;
+          max-height: 80vh;
+          display: flex;
+          flex-direction: column;
+          box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4);
+        }
+
+        .srd-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding: 16px 20px;
+          border-bottom: 1px solid var(--border, #30363d);
+        }
+
+        .srd-title {
+          font-size: 15px;
+          font-weight: 600;
+          margin: 0;
+        }
+
+        .srd-close {
+          background: transparent;
+          border: none;
+          color: var(--text-secondary, #8b949e);
+          font-size: 16px;
+          cursor: pointer;
+          padding: 4px;
+          border-radius: 4px;
+          line-height: 1;
+          transition: color 0.15s;
+        }
+        .srd-close:hover { color: var(--text-primary, #c9d1d9); }
+
+        .srd-body {
+          padding: 16px 20px;
+          overflow-y: auto;
+          flex: 1;
+          display: flex;
+          flex-direction: column;
+          gap: 14px;
+        }
+
+        .srd-error {
+          padding: 8px 12px;
+          border-radius: 6px;
+          background: rgba(248, 81, 73, 0.1);
+          border: 1px solid rgba(248, 81, 73, 0.35);
+          color: #f85149;
+          font-size: 13px;
+          margin: 0;
+        }
+
+        .srd-create-row {
+          display: flex;
+        }
+
+        .srd-create-btn {
+          padding: 7px 16px;
+          border-radius: 6px;
+          font-size: 13px;
+          font-weight: 500;
+          background: var(--accent, #238636);
+          color: #fff;
+          border: none;
+          cursor: pointer;
+          transition: opacity 0.15s;
+        }
+        .srd-create-btn:hover:not(:disabled) { opacity: 0.85; }
+        .srd-create-btn:disabled { opacity: 0.5; cursor: default; }
+
+        .srd-token-box {
+          background: var(--bg-primary, #0d1117);
+          border: 1px solid var(--border, #30363d);
+          border-radius: 6px;
+          padding: 12px;
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+        }
+
+        .srd-token-hint {
+          font-size: 12px;
+          color: var(--text-secondary, #8b949e);
+          margin: 0;
+        }
+
+        .srd-token-row {
+          display: flex;
+          gap: 8px;
+        }
+
+        .srd-token-input {
+          flex: 1;
+          font-family: var(--font-mono, monospace);
+          font-size: 12px;
+          padding: 6px 10px;
+          border-radius: 5px;
+          border: 1px solid var(--border, #30363d);
+          background: var(--bg-secondary, #161b22);
+          color: var(--text-primary, #c9d1d9);
+          min-width: 0;
+        }
+
+        .srd-copy-btn {
+          padding: 6px 14px;
+          border-radius: 5px;
+          font-size: 12px;
+          font-weight: 500;
+          border: 1px solid var(--border, #30363d);
+          background: transparent;
+          color: var(--text-primary, #c9d1d9);
+          cursor: pointer;
+          flex-shrink: 0;
+          transition: background 0.15s;
+        }
+        .srd-copy-btn:hover { background: rgba(255,255,255,0.06); }
+
+        .srd-shares-section {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+        }
+
+        .srd-section-title {
+          font-size: 12px;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.06em;
+          color: var(--text-secondary, #8b949e);
+          margin: 0;
+        }
+
+        .srd-muted {
+          color: var(--text-secondary, #8b949e);
+          font-size: 13px;
+          margin: 0;
+          font-style: italic;
+        }
+
+        .srd-share-list {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+        }
+
+        .srd-share-item {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+          padding: 8px 10px;
+          border-radius: 6px;
+          border: 1px solid var(--border, #30363d);
+          background: var(--bg-primary, #0d1117);
+        }
+
+        .srd-share-info {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: 8px;
+          min-width: 0;
+        }
+
+        .srd-share-prefix {
+          font-size: 12px;
+          color: var(--text-secondary, #8b949e);
+        }
+
+        .srd-share-meta {
+          font-size: 12px;
+          color: var(--text-primary, #c9d1d9);
+        }
+
+        .srd-share-expiry {
+          font-size: 11px;
+          color: var(--warning, #d29922);
+        }
+
+        .srd-share-created {
+          font-size: 11px;
+          color: var(--text-secondary, #8b949e);
+        }
+
+        .mono { font-family: var(--font-mono, monospace); }
+
+        .srd-revoke-btn {
+          padding: 4px 12px;
+          border-radius: 5px;
+          font-size: 12px;
+          border: 1px solid rgba(248, 81, 73, 0.4);
+          background: transparent;
+          color: #f85149;
+          cursor: pointer;
+          flex-shrink: 0;
+          transition: background 0.15s, color 0.15s;
+          white-space: nowrap;
+        }
+        .srd-revoke-btn:hover:not(:disabled) {
+          background: #f85149;
+          color: #fff;
+        }
+        .srd-revoke-btn:disabled { opacity: 0.5; cursor: default; }
+      `}</style>
+    </div>
+  );
+}

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -307,6 +307,8 @@ export const en = {
     event_auth_password_changed: 'Password changed',
     event_auth_admin_user_created: 'Admin created user',
     event_participant_role_changed: 'Role changed',
+    event_recording_started: 'Recording started',
+    event_recording_stopped: 'Recording stopped',
   },
   chat: {
     heading: 'Chat',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -291,6 +291,8 @@ export const zh: Dict = {
     event_auth_password_changed: '密码已更改',
     event_auth_admin_user_created: '管理员创建用户',
     event_participant_role_changed: '角色已更改',
+    event_recording_started: '录制已开始',
+    event_recording_stopped: '录制已结束',
   },
   chat: {
     heading: '聊天',

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -16,6 +16,8 @@ import type {
   SystemInfo,
   ValidateTargetsResult,
   AdminUsersResponse,
+  Recording,
+  RecordingShare,
 } from './protocol';
 
 /**
@@ -583,6 +585,118 @@ export const api = {
       method: 'PUT',
       body: JSON.stringify({ role }),
     });
+  },
+
+  // ── Recordings ──────────────────────────────────────────────────────────────
+
+  /**
+   * Owner-only. Start recording the given session. Returns the new
+   * `Recording` row on success; 409 if a recording is already active.
+   */
+  startRecording(sessionId: string): Promise<Recording> {
+    return request(`/sessions/${sessionId}/recording/start`, { method: 'POST' });
+  },
+
+  /**
+   * Owner-only. Stop an active recording for the given session. The
+   * writer finalizes asynchronously, so the server returns 204 — the UI
+   * should react to the `RecordingStopped` WS broadcast for updated state.
+   */
+  stopRecording(sessionId: string): Promise<void> {
+    return request(`/sessions/${sessionId}/recording/stop`, { method: 'POST' });
+  },
+
+  /**
+   * List recordings visible to the authenticated user. Regular users
+   * see recordings they own; admins see all.
+   */
+  listRecordings(): Promise<Recording[]> {
+    return request('/recordings');
+  },
+
+  /**
+   * Fetch a single recording by its nanoid. Returns 404 if not found
+   * or the caller lacks access.
+   */
+  getRecording(id: string): Promise<Recording> {
+    return request(`/recordings/${id}`);
+  },
+
+  /**
+   * Delete a recording and its on-disk file. Returns 204 on success.
+   * Only the owner (or an admin) may delete.
+   */
+  deleteRecording(id: string): Promise<void> {
+    return request(`/recordings/${id}`, { method: 'DELETE' });
+  },
+
+  /**
+   * Build the URL for streaming a recording's asciicast data. NOT async
+   * — callers embed this in a `<video src>` or pass it to `fetch()`.
+   * An optional share token can be appended for unauthenticated access.
+   */
+  getRecordingDataUrl(id: string, token?: string): string {
+    const base = `${BASE}/recordings/${id}/data`;
+    return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+  },
+
+  /**
+   * Create a share link for a recording. `maxUses` defaults to 1 on the
+   * server; `expiresAt` is an ISO-8601 string or omitted for no TTL.
+   * Returns the share row — the plaintext token is only present here,
+   * not in subsequent list calls.
+   */
+  createRecordingShare(
+    recordingId: string,
+    maxUses?: number,
+    expiresAt?: string,
+  ): Promise<RecordingShare & { token: string }> {
+    return request(`/recordings/${recordingId}/shares`, {
+      method: 'POST',
+      body: JSON.stringify({
+        ...(maxUses != null && { max_uses: maxUses }),
+        ...(expiresAt != null && { expires_at: expiresAt }),
+      }),
+    });
+  },
+
+  /** List all share links for a recording (owner-only). */
+  listRecordingShares(recordingId: string): Promise<RecordingShare[]> {
+    return request(`/recordings/${recordingId}/shares`);
+  },
+
+  /**
+   * Revoke a share link by its SHA-256 digest. Returns 204 on success.
+   */
+  deleteRecordingShare(recordingId: string, tokenSha256: string): Promise<void> {
+    return request(`/recordings/${recordingId}/shares/${tokenSha256}`, {
+      method: 'DELETE',
+    });
+  },
+
+  /**
+   * Mark a recording as "kept" — clears `expires_at` so the TTL reaper
+   * will not purge it. Returns the updated `Recording` row.
+   */
+  keepRecording(id: string): Promise<Recording> {
+    return request(`/recordings/${id}/keep`, { method: 'POST' });
+  },
+
+  /**
+   * Immediately schedule a recording for expiry by setting `expires_at`
+   * to now. Returns the updated `Recording` row.
+   */
+  expireRecording(id: string): Promise<Recording> {
+    return request(`/recordings/${id}/expire`, { method: 'POST' });
+  },
+
+  /**
+   * Admin-only. List all recordings across every user. Returns the same
+   * `Recording[]` shape as `listRecordings()` but with no ownership
+   * filter.
+   */
+  adminListRecordings(): Promise<Recording[]> {
+    return request('/admin/recordings');
   },
 };
 

--- a/web/src/lib/audit.ts
+++ b/web/src/lib/audit.ts
@@ -24,6 +24,8 @@ export const AUDIT_EVENT_LABEL_KEYS: Record<AuditEventType, TranslationKey> = {
   [AuditEventType.AUTH_PASSWORD_CHANGED]: 'session_detail.event_auth_password_changed',
   [AuditEventType.AUTH_ADMIN_USER_CREATED]: 'session_detail.event_auth_admin_user_created',
   [AuditEventType.PARTICIPANT_ROLE_CHANGED]: 'session_detail.event_participant_role_changed',
+  [AuditEventType.RECORDING_STARTED]: 'session_detail.event_recording_started',
+  [AuditEventType.RECORDING_STOPPED]: 'session_detail.event_recording_stopped',
 };
 
 export function eventLabel(t: Translator, type: string): string {

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,0 +1,33 @@
+// web/src/lib/format.ts
+//
+// Display-format helpers shared across the recording pages and dialogs.
+
+const DEFAULT_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'short',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+};
+
+/** Render an ISO-8601 timestamp in the user's locale. Falls back to the
+ *  raw string when the input is unparseable so the UI never shows an
+ *  empty field. */
+export function formatDate(
+  iso: string,
+  options: Intl.DateTimeFormatOptions = DEFAULT_DATE_OPTIONS,
+): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, options);
+  } catch {
+    return iso;
+  }
+}
+
+/** Render a byte count with kilobyte/megabyte units. */
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/web/src/lib/playback.test.ts
+++ b/web/src/lib/playback.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PlaybackEngine } from './playback';
+
+const SAMPLE_CAST = [
+  '{"version":2,"width":80,"height":24,"timestamp":1713264000,"env":{"TERM":"xterm-256color"},"telepair":{}}',
+  '[0.000000, "o", "$ "]',
+  '[0.500000, "o", "ls\\r\\n"]',
+  '[1.000000, "r", "120x30"]',
+  '[1.500000, "j", "{\\"user_id\\":\\"u1\\",\\"name\\":\\"bob\\",\\"role\\":\\"operator\\"}"]',
+  '[2.000000, "o", "file1.txt\\r\\n"]',
+  '[2.500000, "c", "{\\"user_id\\":\\"u1\\",\\"name\\":\\"bob\\",\\"text\\":\\"hi\\"}"]',
+  '[3.000000, "l", "{\\"user_id\\":\\"u1\\"}"]',
+].join('\n');
+
+describe('PlaybackEngine', () => {
+  let engine: PlaybackEngine;
+  beforeEach(() => { engine = new PlaybackEngine(); vi.useFakeTimers(); });
+  afterEach(() => { engine.dispose(); vi.useRealTimers(); });
+
+  it('parses asciicast header', () => {
+    engine.load(SAMPLE_CAST);
+    expect(engine.header.version).toBe(2);
+    expect(engine.header.width).toBe(80);
+  });
+
+  it('parses all events', () => {
+    engine.load(SAMPLE_CAST);
+    expect(engine.events.length).toBe(7);
+    expect(engine.events[0]).toEqual({ time: 0, type: 'o', data: '$ ' });
+  });
+
+  it('reports total duration', () => {
+    engine.load(SAMPLE_CAST);
+    expect(engine.duration).toBe(3.0);
+  });
+
+  it('emits output events during playback', () => {
+    engine.load(SAMPLE_CAST);
+    const outputs: string[] = [];
+    engine.onOutput = (data) => outputs.push(data);
+    engine.play();
+    vi.advanceTimersByTime(100);
+    expect(outputs).toContain('$ ');
+    vi.advanceTimersByTime(500);
+    expect(outputs).toContain('ls\r\n');
+  });
+
+  it('emits resize events', () => {
+    engine.load(SAMPLE_CAST);
+    let resized = false;
+    engine.onResize = (cols, rows) => { resized = true; expect(cols).toBe(120); expect(rows).toBe(30); };
+    engine.play();
+    vi.advanceTimersByTime(1100);
+    expect(resized).toBe(true);
+  });
+
+  it('pauses and resumes', () => {
+    engine.load(SAMPLE_CAST);
+    const outputs: string[] = [];
+    engine.onOutput = (data) => outputs.push(data);
+    engine.play();
+    vi.advanceTimersByTime(100);
+    const countBefore = outputs.length;
+    engine.pause();
+    vi.advanceTimersByTime(2000);
+    expect(outputs.length).toBe(countBefore);
+    engine.play();
+    vi.advanceTimersByTime(600);
+    expect(outputs.length).toBeGreaterThan(countBefore);
+  });
+
+  it('seeks to a specific time', () => {
+    engine.load(SAMPLE_CAST);
+    const outputs: string[] = [];
+    engine.onOutput = (data) => outputs.push(data);
+    engine.seek(2.0);
+    expect(outputs).toContain('$ ');
+    expect(outputs).toContain('ls\r\n');
+    expect(outputs).toContain('file1.txt\r\n');
+  });
+
+  it('respects speed multiplier', () => {
+    engine.load(SAMPLE_CAST);
+    const outputs: string[] = [];
+    engine.onOutput = (data) => outputs.push(data);
+    engine.setSpeed(2);
+    engine.play();
+    vi.advanceTimersByTime(300);
+    expect(outputs).toContain('ls\r\n');
+  });
+
+  it('fires onComplete when playback ends', () => {
+    engine.load(SAMPLE_CAST);
+    let completed = false;
+    engine.onComplete = () => { completed = true; };
+    engine.play();
+    vi.advanceTimersByTime(4000);
+    expect(completed).toBe(true);
+  });
+});

--- a/web/src/lib/playback.ts
+++ b/web/src/lib/playback.ts
@@ -1,0 +1,317 @@
+/**
+ * PlaybackEngine — asciicast v2 parser and playback controller.
+ *
+ * Asciicast v2 format (NDJSON):
+ *   Line 1: JSON header  { version, width, height, timestamp, … }
+ *   Lines 2+: JSON event [time, type, data]
+ *             where type is one of:
+ *               "o" — terminal output (string)
+ *               "r" — terminal resize ("<cols>x<rows>")
+ *               "j" — participant join  (JSON string)
+ *               "l" — participant leave (JSON string)
+ *               "c" — chat message      (JSON string)
+ *
+ * Playback is timer-driven: each event is scheduled with a
+ * `setTimeout` whose delay is `(event.time - currentTime) / speed * 1000`.
+ * Seeking replays all output events from the beginning (a terminal is a
+ * stateful display device — you cannot jump into the middle without
+ * replaying prior state).
+ */
+
+export interface CastHeader {
+  version: number;
+  width: number;
+  height: number;
+  timestamp?: number;
+  title?: string;
+  env?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+export interface CastEvent {
+  time: number;
+  type: string;
+  data: string;
+}
+
+export type PlaybackState = 'idle' | 'playing' | 'paused' | 'ended';
+
+export interface ParticipantPayload {
+  user_id: string;
+  name: string;
+  role?: string;
+}
+
+export interface ChatPayload {
+  user_id: string;
+  name: string;
+  text: string;
+}
+
+export class PlaybackEngine {
+  // ── Parsed content ──────────────────────────────────────────────────────────
+  header!: CastHeader;
+  events: CastEvent[] = [];
+
+  // ── Playback state ──────────────────────────────────────────────────────────
+  state: PlaybackState = 'idle';
+  currentTime = 0;
+  speed = 1;
+
+  // ── Callbacks ───────────────────────────────────────────────────────────────
+  onOutput?: (data: string) => void;
+  onResize?: (cols: number, rows: number) => void;
+  onParticipantJoin?: (payload: ParticipantPayload) => void;
+  onParticipantLeave?: (payload: { user_id: string }) => void;
+  onChat?: (payload: ChatPayload) => void;
+  onComplete?: () => void;
+  onTimeUpdate?: (time: number) => void;
+
+  // ── Internal scheduling ─────────────────────────────────────────────────────
+  /** Index of the next event to be scheduled. */
+  private nextIndex = 0;
+  /** Wall-clock time (ms) when the current play segment started. */
+  private playStartWall = 0;
+  /** Engine time (seconds) at which the current play segment started. */
+  private playStartTime = 0;
+  /** Currently pending timer handles. */
+  private timers: ReturnType<typeof setTimeout>[] = [];
+  /** Timer for the `onTimeUpdate` ticker (100 ms interval). */
+  private tickTimer: ReturnType<typeof setInterval> | null = null;
+
+  // ── Public API ──────────────────────────────────────────────────────────────
+
+  /**
+   * Parse an asciicast v2 string (NDJSON). Clears any previous content
+   * and resets playback to the beginning.
+   */
+  load(castContent: string): void {
+    this.dispose();
+    const lines = castContent.split('\n').filter((l) => l.trim().length > 0);
+    if (lines.length === 0) throw new Error('Empty cast content');
+
+    this.header = JSON.parse(lines[0]) as CastHeader;
+    this.events = lines.slice(1).map((line) => {
+      const [time, type, data] = JSON.parse(line) as [number, string, string];
+      return { time, type, data };
+    });
+
+    this.state = 'idle';
+    this.currentTime = 0;
+    this.nextIndex = 0;
+  }
+
+  /** Total duration in seconds (time of last event). */
+  get duration(): number {
+    if (this.events.length === 0) return 0;
+    return this.events[this.events.length - 1].time;
+  }
+
+  /**
+   * Start or resume playback from `currentTime`. If already playing,
+   * this is a no-op.
+   */
+  play(): void {
+    if (this.state === 'playing') return;
+    if (this.state === 'ended') {
+      // Restart from beginning.
+      this.currentTime = 0;
+      this.nextIndex = 0;
+    }
+
+    this.state = 'playing';
+    this.playStartWall = Date.now();
+    this.playStartTime = this.currentTime;
+
+    this.scheduleRemaining();
+    this.startTicker();
+  }
+
+  /** Pause playback. Current position is preserved for resuming. */
+  pause(): void {
+    if (this.state !== 'playing') return;
+    // Capture how far we have advanced before clearing timers.
+    this.currentTime = this.elapsedTime();
+    this.state = 'paused';
+    this.clearTimers();
+    this.stopTicker();
+  }
+
+  /**
+   * Seek to `timeSeconds`. Replays all output events up to that point
+   * synchronously (terminal state machine), then positions the engine
+   * ready to continue from there. If currently playing, playback
+   * resumes from the new position.
+   */
+  seek(timeSeconds: number): void {
+    const wasPlaying = this.state === 'playing';
+    this.clearTimers();
+    this.stopTicker();
+
+    this.currentTime = Math.max(0, Math.min(timeSeconds, this.duration));
+    this.nextIndex = 0;
+
+    // Replay all output ('o') events up to and including the target time.
+    for (const event of this.events) {
+      if (event.time > this.currentTime) break;
+      this.nextIndex++;
+      if (event.type === 'o') {
+        this.onOutput?.(event.data);
+      }
+      // Emit resize so the terminal dimensions are correct at the seek point.
+      if (event.type === 'r') {
+        this.applyResize(event.data);
+      }
+    }
+
+    if (wasPlaying) {
+      this.state = 'paused'; // will be overridden by play()
+      this.play();
+    }
+  }
+
+  /**
+   * Set the playback speed multiplier (e.g. 0.5, 1, 2, 4). If
+   * currently playing, reschedules pending events at the new rate.
+   */
+  setSpeed(multiplier: number): void {
+    if (multiplier <= 0) throw new Error('Speed must be positive');
+    if (this.state === 'playing') {
+      // Snapshot current position before changing speed.
+      this.currentTime = this.elapsedTime();
+      this.clearTimers();
+      this.stopTicker();
+    }
+    this.speed = multiplier;
+    if (this.state === 'playing') {
+      this.playStartWall = Date.now();
+      this.playStartTime = this.currentTime;
+      this.scheduleRemaining();
+      this.startTicker();
+    }
+  }
+
+  /** Release all timers. Safe to call multiple times. */
+  dispose(): void {
+    this.clearTimers();
+    this.stopTicker();
+    this.state = 'idle';
+  }
+
+  // ── Internal helpers ────────────────────────────────────────────────────────
+
+  /** Engine time (seconds) at the current wall-clock moment. */
+  private elapsedTime(): number {
+    const wallMs = Date.now() - this.playStartWall;
+    return this.playStartTime + (wallMs / 1000) * this.speed;
+  }
+
+  /**
+   * Schedule all events from `nextIndex` onward relative to the play
+   * segment start. Already-elapsed events (delay ≤ 0) are fired
+   * immediately via a zero-delay timeout so the call stack stays clean.
+   */
+  private scheduleRemaining(): void {
+    for (let i = this.nextIndex; i < this.events.length; i++) {
+      const event = this.events[i];
+      const delayMs = Math.max(
+        0,
+        ((event.time - this.playStartTime) / this.speed) * 1000
+          - (Date.now() - this.playStartWall),
+      );
+      const handle = setTimeout(() => {
+        if (this.state !== 'playing') return;
+        this.currentTime = event.time;
+        this.dispatch(event);
+
+        // Check if this was the last event.
+        if (i === this.events.length - 1) {
+          this.state = 'ended';
+          this.stopTicker();
+          this.onComplete?.();
+        }
+      }, delayMs);
+      this.timers.push(handle);
+    }
+    this.nextIndex = this.events.length;
+  }
+
+  private clearTimers(): void {
+    for (const h of this.timers) clearTimeout(h);
+    this.timers = [];
+    this.nextIndex = this.findNextIndex();
+  }
+
+  /** Find the index of the first event whose time is > currentTime. */
+  private findNextIndex(): number {
+    for (let i = 0; i < this.events.length; i++) {
+      if (this.events[i].time > this.currentTime) return i;
+    }
+    return this.events.length;
+  }
+
+  private startTicker(): void {
+    if (this.tickTimer !== null) return;
+    this.tickTimer = setInterval(() => {
+      if (this.state === 'playing') {
+        this.onTimeUpdate?.(this.elapsedTime());
+      }
+    }, 100);
+  }
+
+  private stopTicker(): void {
+    if (this.tickTimer !== null) {
+      clearInterval(this.tickTimer);
+      this.tickTimer = null;
+    }
+  }
+
+  /** Dispatch a single event to the appropriate callback. */
+  private dispatch(event: CastEvent): void {
+    switch (event.type) {
+      case 'o':
+        this.onOutput?.(event.data);
+        break;
+      case 'r':
+        this.applyResize(event.data);
+        break;
+      case 'j':
+        try {
+          const payload = JSON.parse(event.data) as ParticipantPayload;
+          this.onParticipantJoin?.(payload);
+        } catch {
+          // Malformed payload — skip silently.
+        }
+        break;
+      case 'l':
+        try {
+          const payload = JSON.parse(event.data) as { user_id: string };
+          this.onParticipantLeave?.(payload);
+        } catch {
+          // Malformed payload — skip silently.
+        }
+        break;
+      case 'c':
+        try {
+          const payload = JSON.parse(event.data) as ChatPayload;
+          this.onChat?.(payload);
+        } catch {
+          // Malformed payload — skip silently.
+        }
+        break;
+      default:
+        // Unknown event type — ignore for forward-compatibility.
+        break;
+    }
+  }
+
+  /** Parse a resize event data string "<cols>x<rows>" and fire the callback. */
+  private applyResize(data: string): void {
+    const [colsStr, rowsStr] = data.split('x');
+    const cols = parseInt(colsStr, 10);
+    const rows = parseInt(rowsStr, 10);
+    if (!isNaN(cols) && !isNaN(rows)) {
+      this.onResize?.(cols, rows);
+    }
+  }
+}

--- a/web/src/lib/protocol.test.ts
+++ b/web/src/lib/protocol.test.ts
@@ -50,6 +50,7 @@ describe('ServerMessage type narrowing', () => {
       your_role: 'owner',
       your_user_id: '550e8400-e29b-41d4-a716-446655440000',
       chat_history: [],
+      recording: null,
     };
     if (msg.type === 'SessionState') {
       expect(msg.your_role).toBe('owner');

--- a/web/src/lib/protocol.ts
+++ b/web/src/lib/protocol.ts
@@ -159,6 +159,8 @@ export type ServerMessage =
        * duplicate entries found here.
        */
       chat_history: ChatEntry[];
+      /** Non-null when a recording is currently in progress for this session. */
+      recording: RecordingStatusInfo | null;
     }
   | { type: 'PeerJoined'; user_id: string; name: string; role: Role; color: string }
   | { type: 'PeerLeft'; user_id: string }
@@ -190,7 +192,9 @@ export type ServerMessage =
   | { type: 'PeerCursor'; user_id: string; x: number; y: number }
   | { type: 'PeerChat'; user_id: string; name: string; text: string; ts: string }
   | { type: 'InputDenied'; reason: InputDeniedReason }
-  | { type: 'Error'; code: string; message: string };
+  | { type: 'Error'; code: string; message: string }
+  | { type: 'RecordingStarted'; recording_id: string }
+  | { type: 'RecordingStopped'; recording_id: string };
 
 // Reason codes mirroring `crates/telepair-core/src/protocol.rs::input_denied`.
 // The server only sends these strings; any unknown value should be rendered
@@ -229,6 +233,8 @@ export const AuditEventType = {
   AUTH_PASSWORD_CHANGED: 'auth.password_changed',
   AUTH_ADMIN_USER_CREATED: 'auth.admin_user_created',
   PARTICIPANT_ROLE_CHANGED: 'participant.role_changed',
+  RECORDING_STARTED: 'recording.started',
+  RECORDING_STOPPED: 'recording.stopped',
 } as const;
 export type AuditEventType = (typeof AuditEventType)[keyof typeof AuditEventType];
 
@@ -450,4 +456,52 @@ export interface BlockedTarget {
 export interface AdminUsersResponse {
   users: AdminUserInfo[];
   total: number;
+}
+
+// --- Recording types ---
+
+/**
+ * Snapshot of an active recording attached to a session. Delivered
+ * inside `SessionState.recording` when the session was started with
+ * recording enabled, and replaced by `null` once stopped.
+ */
+export interface RecordingStatusInfo {
+  recording_id: string;
+  started_at: string;
+}
+
+/**
+ * Full recording row returned by `GET /api/recordings` and
+ * `GET /api/recordings/{id}`. Mirrors `RecordingInfo` in
+ * `crates/telepair-gateway/src/http.rs`.
+ */
+export interface Recording {
+  id: string;
+  session_id: string;
+  status: 'recording' | 'completed' | 'failed';
+  file_path: string | null;
+  file_size: number;
+  duration_ms: number | null;
+  width: number;
+  height: number;
+  event_count: number;
+  started_at: string;
+  completed_at: string | null;
+  expires_at: string | null;
+  created_by: string;
+}
+
+/**
+ * One share-link row returned by the recording share endpoints.
+ * Mirrors `RecordingShareInfo` in `crates/telepair-gateway/src/http.rs`.
+ * The raw plaintext token is only returned on creation; subsequent
+ * list calls return `token_sha256` as the stable revocation handle.
+ */
+export interface RecordingShare {
+  token_sha256: string;
+  recording_id: string;
+  max_uses: number;
+  used_count: number;
+  expires_at: string | null;
+  created_at: string;
 }

--- a/web/src/lib/ws.test.ts
+++ b/web/src/lib/ws.test.ts
@@ -141,6 +141,7 @@ describe('TelepairSocket', () => {
       your_role: 'owner',
       your_user_id: 'u',
       chat_history: [],
+      recording: null,
     };
     ws.onmessage?.({ data: JSON.stringify(state) });
 

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -310,6 +310,11 @@ export default function Dashboard() {
               {t('dashboard.change_password_link')}
             </a>
           </Show>
+          <Show when={!auth.currentUserIsGuest()}>
+            <a class="admin-link" href="/recordings" data-testid="recordings-link">
+              Recordings
+            </a>
+          </Show>
           <button
             class="refresh-btn"
             onClick={handleRefresh}

--- a/web/src/pages/RecordingPlayer.tsx
+++ b/web/src/pages/RecordingPlayer.tsx
@@ -1,0 +1,423 @@
+// web/src/pages/RecordingPlayer.tsx
+import { createSignal, onMount, onCleanup, Show } from 'solid-js';
+import { useParams, useSearchParams, useNavigate } from '@solidjs/router';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import '@xterm/xterm/css/xterm.css';
+import { api, errorMessage } from '../lib/api';
+import { formatBytes, formatDate } from '../lib/format';
+import type { Recording } from '../lib/protocol';
+import { PlaybackEngine } from '../lib/playback';
+import type { ParticipantPayload, ChatPayload } from '../lib/playback';
+import PlaybackControls from '../components/PlaybackControls';
+import Banner from '../components/Banner';
+import CollabSidebar from '../components/CollabSidebar';
+import type { CollabChatMessage } from '../components/CollabSidebar';
+import EventTimeline from '../components/EventTimeline';
+
+export default function RecordingPlayer() {
+  const params = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams<{ token?: string }>();
+  const navigate = useNavigate();
+
+  const shareToken = () => searchParams.token;
+
+  // ── State ──────────────────────────────────────────────────────────────────
+  const [recording, setRecording] = createSignal<Recording | null>(null);
+  const [loading, setLoading] = createSignal(true);
+  const [error, setError] = createSignal('');
+  const [isPlaying, setIsPlaying] = createSignal(false);
+  const [currentTime, setCurrentTime] = createSignal(0);
+  const [duration, setDuration] = createSignal(0);
+  const [speed, setSpeed] = createSignal(1);
+
+  // ── Collab state ───────────────────────────────────────────────────────────
+  const [participants, setParticipants] = createSignal<ParticipantPayload[]>([]);
+  const [chatMessages, setChatMessages] = createSignal<CollabChatMessage[]>([]);
+
+  // ── Refs ───────────────────────────────────────────────────────────────────
+  let terminalContainer: HTMLDivElement | undefined;
+  let playerContainer: HTMLDivElement | undefined;
+  let term: XTerm | undefined;
+  let fitAddon: FitAddon | undefined;
+  let engine: PlaybackEngine | undefined;
+
+  onMount(async () => {
+    await initPlayer();
+  });
+
+  onCleanup(() => {
+    engine?.dispose();
+    term?.dispose();
+  });
+
+  async function initPlayer() {
+    setLoading(true);
+    setError('');
+
+    try {
+      // Fetch recording metadata — skip for anonymous share tokens since
+      // the data endpoint itself is what we need; metadata 403s for anon.
+      let rec: Recording | null = null;
+      if (!shareToken()) {
+        rec = await api.getRecording(params.id);
+        setRecording(rec);
+      }
+
+      // Fetch the asciicast data file. For share-token (anonymous) access
+      // we use a bare fetch with the token in the URL. For authenticated
+      // access we go through api.downloadBlob so the global 401 interceptor
+      // fires on expired tokens.
+      let castContent: string;
+      const token = shareToken();
+      if (token) {
+        const dataUrl = api.getRecordingDataUrl(params.id, token);
+        const resp = await fetch(dataUrl);
+        if (!resp.ok) {
+          throw new Error(`Failed to fetch recording data: ${resp.status} ${resp.statusText}`);
+        }
+        castContent = await resp.text();
+      } else {
+        const path = `/recordings/${params.id}/data`;
+        const { blob } = await api.downloadBlob(path);
+        castContent = await blob.text();
+      }
+
+      // Reveal the player layout *before* we reach for the terminal
+      // container ref. The container lives inside `<Show when={!loading() && !error()}>`,
+      // so its ref callback only fires once `loading()` flips to false —
+      // checking it any earlier always yields undefined and throws the
+      // bogus "Terminal container missing" below. A microtask yield
+      // lets Solid flush the render triggered by setLoading before
+      // xterm tries to mount.
+      setLoading(false);
+      await Promise.resolve();
+
+      // ── Initialise xterm ────────────────────────────────────────────────
+      if (!terminalContainer) throw new Error('Terminal container missing');
+
+      const initialWidth = rec?.width ?? 80;
+      const initialHeight = rec?.height ?? 24;
+
+      term = new XTerm({
+        disableStdin: true,
+        cursorBlink: false,
+        cols: initialWidth,
+        rows: initialHeight,
+        scrollback: 10000,
+        theme: {
+          background: '#0d1117',
+          foreground: '#c9d1d9',
+          cursor: '#c9d1d9',
+        },
+      });
+      fitAddon = new FitAddon();
+      term.loadAddon(fitAddon);
+      term.open(terminalContainer);
+      fitAddon.fit();
+
+      // ── Initialise PlaybackEngine ────────────────────────────────────────
+      engine = new PlaybackEngine();
+      engine.load(castContent);
+
+      setDuration(engine.duration);
+
+      engine.onOutput = (data) => term?.write(data);
+      engine.onResize = (cols, rows) => {
+        if (term) {
+          term.resize(cols, rows);
+          fitAddon?.fit();
+        }
+      };
+      engine.onTimeUpdate = (t) => setCurrentTime(t);
+      engine.onComplete = () => {
+        setIsPlaying(false);
+        setCurrentTime(engine!.duration);
+      };
+
+      // ── Collab callbacks ─────────────────────────────────────────────────
+      engine.onParticipantJoin = (payload: ParticipantPayload) => {
+        setParticipants((prev) => {
+          if (prev.some((p) => p.user_id === payload.user_id)) {
+            return prev.map((p) => p.user_id === payload.user_id ? { ...p, ...payload } : p);
+          }
+          return [...prev, payload];
+        });
+      };
+      engine.onParticipantLeave = (payload: { user_id: string }) => {
+        setParticipants((prev) => prev.filter((p) => p.user_id !== payload.user_id));
+      };
+      engine.onChat = (payload: ChatPayload) => {
+        // currentTime at callback invocation is the event time
+        setChatMessages((prev) => [
+          ...prev,
+          { ...payload, time: engine!.currentTime },
+        ]);
+      };
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // ── Controls ───────────────────────────────────────────────────────────────
+
+  function handlePlayPause() {
+    if (!engine) return;
+    if (isPlaying()) {
+      engine.pause();
+      setIsPlaying(false);
+    } else {
+      engine.play();
+      setIsPlaying(true);
+    }
+  }
+
+  function handleSeek(seconds: number) {
+    if (!engine) return;
+    // Seeking replays from the beginning. xterm's `clear()` only
+    // wipes the active viewport — it pushes existing rows into the
+    // scrollback buffer, so a subsequent replay would stack on top
+    // and the user would see doubled history when scrolling up.
+    // `reset()` wipes both viewport and scrollback, which is what
+    // we want for a "rewind and play again" semantic.
+    term?.reset();
+    // Reset collab state so participants / chat are rebuilt from the seek point.
+    setParticipants([]);
+    setChatMessages([]);
+    engine.seek(seconds);
+    setCurrentTime(seconds);
+    // If the engine was playing before seek(), it resumes automatically.
+    setIsPlaying(engine.state === 'playing');
+  }
+
+  function handleSpeedChange(s: number) {
+    setSpeed(s);
+    engine?.setSpeed(s);
+  }
+
+  function handleFullscreen() {
+    if (!playerContainer) return;
+    if (!document.fullscreenElement) {
+      playerContainer.requestFullscreen?.();
+    } else {
+      document.exitFullscreen?.();
+    }
+  }
+
+  return (
+    <div class="player-page">
+      <header class="topbar">
+        <div class="topbar-left">
+          <Show when={!shareToken()}>
+            <a class="back-link" href="/recordings">&#8592; Recordings</a>
+          </Show>
+          <h1>
+            <Show when={recording()} fallback={<span>Recording Playback</span>}>
+              {(rec) => <span>Recording: {rec().id}</span>}
+            </Show>
+          </h1>
+        </div>
+      </header>
+
+      <Show when={error()}>
+        <Banner variant="error" onDismiss={() => setError('')}>
+          {error()}
+        </Banner>
+      </Show>
+
+      <Show when={loading()}>
+        <div class="loading-overlay">
+          <p class="muted">Loading recording…</p>
+        </div>
+      </Show>
+
+      <Show when={!loading() && !error()}>
+        <div class="player-layout">
+          {/* Main area: terminal + controls */}
+          <div class="player-main">
+            <div class="player-wrapper" ref={playerContainer}>
+              <div class="terminal-container" ref={terminalContainer} />
+              {/* EventTimeline overlays the progress bar area */}
+              <div class="pb-progress-overlay">
+                <EventTimeline events={engine?.events ?? []} duration={duration()} />
+              </div>
+              <PlaybackControls
+                currentTime={currentTime()}
+                duration={duration()}
+                isPlaying={isPlaying()}
+                speed={speed()}
+                disabled={!engine}
+                onPlayPause={handlePlayPause}
+                onSeek={handleSeek}
+                onSpeedChange={handleSpeedChange}
+                onFullscreen={handleFullscreen}
+              />
+            </div>
+
+            {/* Metadata panel */}
+            <Show when={recording()}>
+              {(rec) => (
+                <div class="meta-panel">
+                  <h2>Recording Info</h2>
+                  <dl class="meta-dl">
+                    <dt>Session ID</dt>
+                    <dd class="mono">{rec().session_id}</dd>
+
+                    <dt>Status</dt>
+                    <dd>{rec().status}</dd>
+
+                    <dt>Duration</dt>
+                    <dd>
+                      {rec().duration_ms != null
+                        ? `${(rec().duration_ms! / 1000).toFixed(1)}s`
+                        : '--'}
+                    </dd>
+
+                    <dt>File size</dt>
+                    <dd>{formatBytes(rec().file_size)}</dd>
+
+                    <dt>Dimensions</dt>
+                    <dd>{rec().width}×{rec().height}</dd>
+
+                    <dt>Events</dt>
+                    <dd>{rec().event_count.toLocaleString()}</dd>
+
+                    <dt>Started</dt>
+                    <dd>{formatDate(rec().started_at)}</dd>
+
+                    <Show when={rec().completed_at}>
+                      <dt>Completed</dt>
+                      <dd>{formatDate(rec().completed_at!)}</dd>
+                    </Show>
+
+                    <Show when={rec().expires_at}>
+                      <dt>Expires</dt>
+                      <dd class="warn">{formatDate(rec().expires_at!)}</dd>
+                    </Show>
+                  </dl>
+                </div>
+              )}
+            </Show>
+          </div>
+
+          {/* CollabSidebar */}
+          <CollabSidebar
+            participants={participants()}
+            chatMessages={chatMessages()}
+            currentTime={currentTime()}
+          />
+        </div>
+      </Show>
+
+      <style>{`
+        .player-page { min-height: 100vh; display: flex; flex-direction: column; }
+
+        .topbar {
+          display: flex;
+          align-items: center;
+          padding: 12px 24px;
+          border-bottom: 1px solid var(--border);
+          background: var(--bg-secondary);
+        }
+        .topbar-left { display: flex; align-items: center; gap: 16px; }
+        .topbar h1 { font-size: 16px; font-weight: 600; }
+        .back-link {
+          font-size: 13px;
+          color: var(--text-secondary);
+          text-decoration: none;
+          transition: color 0.15s;
+        }
+        .back-link:hover { color: var(--text-primary); }
+
+        .loading-overlay {
+          flex: 1;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 48px;
+        }
+        .muted { color: var(--text-secondary); font-size: 14px; }
+
+        /* Outer layout: main area (terminal + meta) + right sidebar */
+        .player-layout {
+          flex: 1;
+          display: flex;
+          flex-direction: row;
+          overflow: hidden;
+        }
+
+        /* Left column: stacks terminal wrapper + meta panel vertically */
+        .player-main {
+          flex: 1;
+          display: flex;
+          flex-direction: column;
+          min-width: 0;
+          overflow-y: auto;
+        }
+
+        /* The terminal sits inside a black wrapper — it should fill the width
+           and show a fixed-height terminal viewport above the controls bar. */
+        .player-wrapper {
+          background: #0d1117;
+          display: flex;
+          flex-direction: column;
+          min-height: 0;
+          position: relative;
+        }
+        .terminal-container {
+          flex: 1;
+          min-height: 400px;
+          overflow: hidden;
+          padding: 8px;
+        }
+
+        /* EventTimeline overlay sits inside the pb-controls progress track.
+           We position a thin relative wrapper just before PlaybackControls
+           renders its own .pb-progress-track, so the overlay aligns exactly. */
+        .pb-progress-overlay {
+          position: relative;
+          height: 4px;
+          margin: 4px 12px 0;
+          pointer-events: none;
+        }
+
+        /* When fullscreened, the player wrapper fills the screen. */
+        .player-wrapper:fullscreen,
+        .player-wrapper:-webkit-full-screen {
+          width: 100vw;
+          height: 100vh;
+        }
+        .player-wrapper:fullscreen .terminal-container,
+        .player-wrapper:-webkit-full-screen .terminal-container {
+          flex: 1;
+        }
+
+        /* Metadata panel */
+        .meta-panel {
+          padding: 20px 24px;
+          border-top: 1px solid var(--border);
+          background: var(--bg-secondary);
+          box-sizing: border-box;
+        }
+        .meta-panel h2 {
+          font-size: 14px;
+          font-weight: 600;
+          color: var(--text-secondary);
+          margin-bottom: 12px;
+        }
+        .meta-dl {
+          display: grid;
+          grid-template-columns: 120px 1fr;
+          gap: 6px 16px;
+          font-size: 13px;
+        }
+        .meta-dl dt { color: var(--text-secondary); }
+        .meta-dl dd { color: var(--text-primary); margin: 0; }
+        .mono { font-family: var(--font-mono); font-size: 12px; }
+        .warn { color: var(--warning, #d29922); }
+      `}</style>
+    </div>
+  );
+}

--- a/web/src/pages/Recordings.tsx
+++ b/web/src/pages/Recordings.tsx
@@ -1,0 +1,425 @@
+// web/src/pages/Recordings.tsx
+import { createSignal, onMount, Show, For, createMemo } from 'solid-js';
+import { useNavigate } from '@solidjs/router';
+import { api, errorMessage } from '../lib/api';
+import { formatBytes, formatDate } from '../lib/format';
+import type { Recording } from '../lib/protocol';
+import { auth } from '../stores/auth';
+import { toast } from '../stores/toast';
+import Banner from '../components/Banner';
+import LocaleSwitcher from '../components/LocaleSwitcher';
+
+type StatusFilter = 'all' | 'completed' | 'recording' | 'failed';
+
+const STATUS_FILTERS: StatusFilter[] = ['all', 'completed', 'recording', 'failed'];
+
+function formatDurationMs(ms: number | null): string {
+  if (ms == null || ms <= 0) return '--';
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ${sec % 60}s`;
+  const hr = Math.floor(min / 60);
+  return `${hr}h ${min % 60}m`;
+}
+
+export default function Recordings() {
+  const navigate = useNavigate();
+
+  const [recordings, setRecordings] = createSignal<Recording[]>([]);
+  const [loading, setLoading] = createSignal(true);
+  const [error, setError] = createSignal('');
+  const [statusFilter, setStatusFilter] = createSignal<StatusFilter>('all');
+  const [busyId, setBusyId] = createSignal<string | null>(null);
+
+  onMount(async () => {
+    await loadRecordings();
+  });
+
+  async function loadRecordings() {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await api.listRecordings();
+      setRecordings(data);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const filtered = createMemo(() => {
+    const filter = statusFilter();
+    const all = recordings();
+    if (filter === 'all') return all;
+    return all.filter((r) => r.status === filter);
+  });
+
+  async function handleDelete(r: Recording) {
+    if (busyId()) return;
+    if (!confirm(`Delete recording ${r.id}? This cannot be undone.`)) return;
+    setBusyId(r.id);
+    try {
+      await api.deleteRecording(r.id);
+      setRecordings((prev) => prev.filter((x) => x.id !== r.id));
+      toast.success('Recording deleted');
+    } catch (e) {
+      toast.error(errorMessage(e));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleKeep(r: Recording) {
+    if (busyId()) return;
+    setBusyId(r.id);
+    try {
+      const updated = await api.keepRecording(r.id);
+      setRecordings((prev) => prev.map((x) => (x.id === updated.id ? updated : x)));
+      toast.success('Recording kept (no expiry)');
+    } catch (e) {
+      toast.error(errorMessage(e));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleExpire(r: Recording) {
+    if (busyId()) return;
+    setBusyId(r.id);
+    try {
+      const updated = await api.expireRecording(r.id);
+      setRecordings((prev) => prev.map((x) => (x.id === updated.id ? updated : x)));
+      toast.success('Recording scheduled for expiry');
+    } catch (e) {
+      toast.error(errorMessage(e));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  function statusBadgeData(status: Recording['status']): { label: string; cls: string } {
+    switch (status) {
+      case 'completed':
+        return { label: 'Completed', cls: 'badge-completed' };
+      case 'recording':
+        return { label: 'Recording', cls: 'badge-recording' };
+      case 'failed':
+        return { label: 'Failed', cls: 'badge-failed' };
+    }
+  }
+
+  return (
+    <div class="recordings-page">
+      <header class="topbar">
+        <div class="topbar-left">
+          <a class="back-link" href="/">&#8592; Dashboard</a>
+          <h1>Recordings</h1>
+        </div>
+        <div class="topbar-actions">
+          <LocaleSwitcher variant="topbar" />
+          <button
+            class="refresh-btn"
+            onClick={loadRecordings}
+            disabled={loading()}
+            title="Refresh"
+          >
+            {loading() ? 'Refreshing…' : 'Refresh'}
+          </button>
+          <button onClick={() => auth.logout()}>Logout</button>
+        </div>
+      </header>
+
+      <Show when={error()}>
+        <Banner variant="error" onDismiss={() => setError('')}>
+          {error()}
+        </Banner>
+      </Show>
+
+      <main class="content">
+        {/* Status filter tabs */}
+        <div class="filter-tabs" role="tablist" aria-label="Status filter">
+          <For each={STATUS_FILTERS}>
+            {(f) => (
+              <button
+                type="button"
+                class="filter-tab"
+                role="tab"
+                aria-selected={statusFilter() === f}
+                onClick={() => setStatusFilter(f)}
+              >
+                {f === 'all' ? 'All' : f.charAt(0).toUpperCase() + f.slice(1)}
+              </button>
+            )}
+          </For>
+        </div>
+
+        <Show
+          when={!loading()}
+          fallback={
+            <div class="loading-state">
+              <p class="muted">Loading recordings…</p>
+            </div>
+          }
+        >
+          <Show
+            when={filtered().length > 0}
+            fallback={
+              <div class="empty-state">
+                <p class="empty-title">No recordings found</p>
+                <p class="empty-body">
+                  {statusFilter() === 'all'
+                    ? 'Start a session and click "Start Recording" to create one.'
+                    : `No recordings with status "${statusFilter()}".`}
+                </p>
+              </div>
+            }
+          >
+            <div class="recordings-list">
+              <For each={filtered()}>
+                {(rec) => {
+                  const badge = () => statusBadgeData(rec.status);
+                  const busy = () => busyId() === rec.id;
+                  return (
+                    <div class="recording-card" data-status={rec.status}>
+                      <div class="rec-header">
+                        <span class={`rec-badge ${badge().cls}`}>{badge().label}</span>
+                        <span class="rec-id">{rec.id}</span>
+                        <Show when={rec.expires_at}>
+                          <span class="rec-expires" title={`Expires: ${rec.expires_at}`}>
+                            Expires {formatDate(rec.expires_at!)}
+                          </span>
+                        </Show>
+                      </div>
+
+                      <div class="rec-body">
+                        <div class="rec-meta-grid">
+                          <span class="meta-label">Session</span>
+                          <span class="meta-value mono">{rec.session_id}</span>
+
+                          <span class="meta-label">Duration</span>
+                          <span class="meta-value">{formatDurationMs(rec.duration_ms)}</span>
+
+                          <span class="meta-label">Size</span>
+                          <span class="meta-value">{formatBytes(rec.file_size)}</span>
+
+                          <span class="meta-label">Dimensions</span>
+                          <span class="meta-value">{rec.width}×{rec.height}</span>
+
+                          <span class="meta-label">Events</span>
+                          <span class="meta-value">{rec.event_count.toLocaleString()}</span>
+
+                          <span class="meta-label">Started</span>
+                          <span class="meta-value">{formatDate(rec.started_at)}</span>
+
+                          <Show when={rec.completed_at}>
+                            <span class="meta-label">Completed</span>
+                            <span class="meta-value">{formatDate(rec.completed_at!)}</span>
+                          </Show>
+                        </div>
+                      </div>
+
+                      <div class="rec-actions">
+                        <Show when={rec.status === 'completed'}>
+                          <button
+                            type="button"
+                            class="action-btn action-play"
+                            onClick={() => navigate(`/recordings/${rec.id}`)}
+                            disabled={busy()}
+                          >
+                            ▶ Play
+                          </button>
+                        </Show>
+
+                        <Show when={rec.expires_at}>
+                          <button
+                            type="button"
+                            class="action-btn action-keep"
+                            onClick={() => handleKeep(rec)}
+                            disabled={busy()}
+                            title="Remove expiry — keep this recording forever"
+                          >
+                            Keep
+                          </button>
+                        </Show>
+
+                        <Show when={!rec.expires_at && rec.status === 'completed'}>
+                          <button
+                            type="button"
+                            class="action-btn action-expire"
+                            onClick={() => handleExpire(rec)}
+                            disabled={busy()}
+                            title="Schedule for expiry"
+                          >
+                            Set TTL
+                          </button>
+                        </Show>
+
+                        <button
+                          type="button"
+                          class="action-btn action-delete"
+                          onClick={() => handleDelete(rec)}
+                          disabled={busy()}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </div>
+                  );
+                }}
+              </For>
+            </div>
+          </Show>
+        </Show>
+      </main>
+
+      <style>{`
+        .recordings-page { min-height: 100vh; }
+
+        .topbar {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding: 12px 24px;
+          border-bottom: 1px solid var(--border);
+          background: var(--bg-secondary);
+        }
+        .topbar-left {
+          display: flex;
+          align-items: center;
+          gap: 16px;
+        }
+        .topbar h1 { font-size: 18px; font-weight: 700; }
+        .topbar-actions { display: flex; gap: 8px; align-items: center; }
+        .back-link {
+          font-size: 13px;
+          color: var(--text-secondary);
+          text-decoration: none;
+          transition: color 0.15s;
+        }
+        .back-link:hover { color: var(--text-primary); }
+        .refresh-btn:disabled { opacity: 0.6; cursor: default; }
+
+        .content { padding: 24px; max-width: 960px; margin: 0 auto; }
+
+        .filter-tabs {
+          display: flex;
+          gap: 4px;
+          margin-bottom: 16px;
+        }
+        .filter-tab {
+          background: transparent;
+          border: 1px solid var(--border);
+          color: var(--text-secondary);
+          padding: 6px 14px;
+          border-radius: 999px;
+          font: inherit;
+          font-size: 13px;
+          cursor: pointer;
+          transition: all 0.15s;
+        }
+        .filter-tab:hover { border-color: var(--accent); color: var(--text-primary); }
+        .filter-tab[aria-selected='true'] {
+          background: var(--accent);
+          border-color: var(--accent);
+          color: var(--bg-primary);
+        }
+
+        .loading-state, .empty-state {
+          border: 1px dashed var(--border);
+          border-radius: 8px;
+          padding: 24px;
+          background: var(--bg-secondary);
+          text-align: center;
+        }
+        .empty-title { font-weight: 600; margin-bottom: 6px; color: var(--text-primary); }
+        .empty-body { color: var(--text-secondary); font-size: 13px; }
+        .muted { color: var(--text-secondary); font-size: 14px; }
+
+        .recordings-list { display: flex; flex-direction: column; gap: 10px; }
+
+        .recording-card {
+          background: var(--bg-secondary);
+          border: 1px solid var(--border);
+          border-radius: 8px;
+          padding: 14px 16px;
+          transition: border-color 0.15s;
+        }
+        .recording-card[data-status='failed'] { opacity: 0.7; }
+
+        .rec-header {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+          margin-bottom: 10px;
+        }
+        .rec-id {
+          font-family: var(--font-mono);
+          font-size: 12px;
+          color: var(--accent);
+          flex: 1;
+        }
+        .rec-expires {
+          font-size: 11px;
+          color: var(--warning, #d29922);
+          border: 1px solid var(--warning, #d29922);
+          padding: 2px 8px;
+          border-radius: 10px;
+        }
+
+        .rec-badge {
+          display: inline-block;
+          font-size: 11px;
+          font-weight: 600;
+          padding: 2px 8px;
+          border-radius: 10px;
+          border: 1px solid;
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+        }
+        .badge-completed { color: var(--success, #3fb950); border-color: var(--success, #3fb950); }
+        .badge-recording { color: #f88; border-color: #f88; }
+        .badge-failed    { color: var(--error, #f85149); border-color: var(--error, #f85149); }
+
+        .rec-body { margin-bottom: 12px; }
+        .rec-meta-grid {
+          display: grid;
+          grid-template-columns: 90px 1fr;
+          gap: 4px 12px;
+          font-size: 13px;
+        }
+        .meta-label { color: var(--text-secondary); }
+        .meta-value { color: var(--text-primary); }
+        .mono { font-family: var(--font-mono); font-size: 12px; }
+
+        .rec-actions {
+          display: flex;
+          gap: 8px;
+          flex-wrap: wrap;
+        }
+        .action-btn {
+          font: inherit;
+          font-size: 12px;
+          padding: 5px 12px;
+          border-radius: 6px;
+          cursor: pointer;
+          border: 1px solid var(--border);
+          background: transparent;
+          color: var(--text-secondary);
+          transition: all 0.15s;
+        }
+        .action-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--text-primary); }
+        .action-btn:disabled { opacity: 0.5; cursor: default; }
+        .action-play {
+          border-color: var(--accent);
+          color: var(--accent);
+          font-weight: 600;
+        }
+        .action-play:hover:not(:disabled) { background: var(--accent); color: var(--bg-primary); }
+        .action-delete { color: var(--error, #f85149); border-color: var(--error, #f85149); }
+        .action-delete:hover:not(:disabled) { background: var(--error, #f85149); color: var(--bg-primary); }
+      `}</style>
+    </div>
+  );
+}

--- a/web/src/pages/Session.tsx
+++ b/web/src/pages/Session.tsx
@@ -16,6 +16,8 @@ import InviteDialog from '../components/InviteDialog';
 import Banner from '../components/Banner';
 import LocaleSwitcher from '../components/LocaleSwitcher';
 import SettingsPanel from '../components/SettingsPanel';
+import RecordingIndicator from '../components/RecordingIndicator';
+import ShareRecordingDialog from '../components/ShareRecordingDialog';
 import { toast } from '../stores/toast';
 import { terminalSettings } from '../stores/settings';
 import { notify } from '../lib/notifications';
@@ -81,6 +83,9 @@ export default function SessionPage() {
   const [participants, setParticipants] = createSignal<ParticipantInfo[]>([]);
   const [chatMessages, setChatMessages] = createSignal<ChatMessage[]>([]);
   const [showInvite, setShowInvite] = createSignal(false);
+  const [isRecording, setIsRecording] = createSignal(false);
+  const [recordingId, setRecordingId] = createSignal<string | null>(null);
+  const [showShareDialog, setShowShareDialog] = createSignal(false);
   // Initial sidebar state is viewport-dependent: on narrow screens
   // (<=640px matches the @media rule below) the sidebar promotes to a
   // full-width overlay drawer that covers the terminal, so defaulting
@@ -164,6 +169,14 @@ export default function SessionPage() {
         setRolePinned(true);
         setInputMode(msg.session.input_mode);
         setParticipants(msg.participants);
+        // Sync recording status from the session snapshot.
+        if (msg.recording != null) {
+          setIsRecording(true);
+          setRecordingId(msg.recording.recording_id);
+        } else {
+          setIsRecording(false);
+          setRecordingId(null);
+        }
         // Seed the chat panel from the server's bounded backlog on the
         // FIRST SessionState only. A reconnect delivers SessionState
         // again, but by then local state is richer than the server
@@ -278,6 +291,14 @@ export default function SessionPage() {
         break;
       case 'Error':
         handleServerError(msg.code, msg.message);
+        break;
+      case 'RecordingStarted':
+        setIsRecording(true);
+        setRecordingId(msg.recording_id);
+        break;
+      case 'RecordingStopped':
+        setIsRecording(false);
+        setRecordingId(msg.recording_id);
         break;
     }
   };
@@ -448,6 +469,15 @@ export default function SessionPage() {
     }
   };
 
+  const handleStopRecording = async () => {
+    try {
+      await api.stopRecording(params.id);
+      // State will update via RecordingStopped WS message.
+    } catch (e) {
+      toast.error(`Failed to stop recording: ${fmtError(e)}`);
+    }
+  };
+
   // Return button dispatch: the choice between "back to dashboard"
   // and "log out" is a property of the CREDENTIAL, not the session
   // role. A scoped-guest token is only valid for this one session
@@ -545,10 +575,18 @@ export default function SessionPage() {
         <span class="role-badge" data-role={role()}>{roleLabel(t, role())}</span>
         <span class="status-dot" data-status={status()} />
         <div class="topbar-actions">
+          <RecordingIndicator
+            isRecording={isRecording()}
+            isOwner={role() === 'owner'}
+            onStop={handleStopRecording}
+          />
           <LocaleSwitcher variant="topbar" />
           <SettingsPanel />
           <Show when={role() === 'owner' && !endedReasonKey()}>
             <button class="action-btn" onClick={() => setShowInvite(true)}>{t('session.invite')}</button>
+            <Show when={recordingId() && !isRecording()}>
+              <button class="action-btn" onClick={() => setShowShareDialog(true)}>Share Rec</button>
+            </Show>
             <button
               class={closeArmed() ? 'action-btn danger armed' : 'action-btn danger'}
               onClick={handleCloseSession}
@@ -660,6 +698,13 @@ export default function SessionPage() {
         open={showInvite()}
         onClose={() => setShowInvite(false)}
       />
+
+      <Show when={showShareDialog() && recordingId()}>
+        <ShareRecordingDialog
+          recordingId={recordingId()!}
+          onClose={() => setShowShareDialog(false)}
+        />
+      </Show>
 
       <style>{`
         .session-page {


### PR DESCRIPTION
Release PR for **v0.1.8**. Four condensed commits:

1. `feat(recording): session recording subsystem` — full asciicast v2 capture/playback pipeline (storage, writer, cleaner, REST + WS + CLI, Web player, permissions, audit).
2. `docs(changelog): backfill v0.1.7 section` — retroactively documents the v0.1.7 tag that shipped without a CHANGELOG entry.
3. `chore(release): prepare v0.1.8` — version bump across 5 crates + web + CHANGELOG promote.
4. `fix(recording): close revoke scope, delete-while-active, and silent drop gaps` — three high-severity Codex-review findings folded into v0.1.8.

CHANGELOG section copied below.

---

## [0.1.8] - 2026-04-17

Minor release centred on **session recording and playback**. Live
sessions can be captured as asciicast v2 `.cast` files on demand,
replayed in the browser with play / pause / seek / speed controls, and
shared via public signed links with configurable expiry and use
quotas. The subsystem ships with a streaming writer (1 s timer /
64 KiB threshold flush), a TTL background cleaner, full REST +
WebSocket + CLI surfaces, and a collaboration-aware playback UI that
replays participants and chat timelines in step with PTY output.

The release also lands a focused **security pass** on the auth and
share-link paths — per-IP throttling now covers `/api/auth/login` and
`/api/auth/verify` (previously only `/api/auth/register`), share-link
revocation URLs carry the SHA-256 digest instead of the raw token,
share-token validation runs as a single atomic `UPDATE … RETURNING`
closing a TOCTOU race on `max_uses`, and share revoke itself is now
scoped by `(recording_id, token_sha256)` so one owner cannot revoke
another owner's share links by computing their SHA-256 from the
(non-secret) raw URL.

Two new tables (`recordings`, `recording_shares`) are applied
idempotently at boot. Two new additive `ServerMessage` variants
(`RecordingStarted`, `RecordingStopped`) and two new audit event
types (`recording.started`, `recording.stopped`) land on the wire;
no existing message, column, or response shape changes. Drop-in
upgrade from 0.1.7.

### Added — Session recording

- New session recording subsystem: opt-in `.cast` (asciicast v2)
  capture of every active session, with a streaming writer that
  flushes on a 1 s timer or 64 KiB threshold and a TTL background
  task that purges expired recordings.
- REST surface for recordings: `POST /api/sessions/:id/recording/{start,stop}`,
  `GET /api/recordings`, `GET /api/recordings/:id`, `GET /api/recordings/:id/data`,
  `DELETE /api/recordings/:id`, `POST /api/recordings/:id/{keep,expire}`,
  plus share-link CRUD at `/api/recordings/:id/shares` and a public
  `?token=` access path on the `/data` endpoint.
- Browser playback page powered by xterm.js with play / pause /
  seek / speed controls, a participant + chat sidebar replayed in
  step with PTY output, and an event timeline of the recorded
  collab messages.
- WebSocket `RecordingStarted` / `RecordingStopped` server messages
  so every connected client surfaces the live indicator.
- New audit event types `recording.started` / `recording.stopped`
  written by the gateway and rendered in the admin audit timeline.
- New CLI flags `--recording-enabled`, `--recording-dir`,
  `--recording-ttl-days` (and matching `TELEPAIR_*` env vars), with
  `--recording-enabled=false` now actually rejecting `start_recording`
  requests at the HTTP layer.

### Security

- `POST /api/auth/login` and `POST /api/auth/verify` now share the
  per-IP throttle that already protected `/api/auth/register`,
  closing a credential-stuffing / OTP brute-force gap (the
  per-account 5-strike lockout and per-email OTP throttle were not
  enough on their own).
- `DELETE /api/recordings/:id/shares/:token_sha256` now takes the
  SHA-256 digest in the URL — putting the raw share token in the
  path leaked it into access logs and Referer headers.
- Share-token validation runs as a single `UPDATE … RETURNING` that
  checks expiry, remaining uses, and the requested recording id in
  one statement. The previous read-then-update sequence had a TOCTOU
  race on `max_uses` and let any holder of one recording's token
  burn quota by hitting another recording's URL.
- `DELETE /api/recordings/:id/shares/:token_sha256` now scopes the
  delete to `(recording_id, token_sha256)` at the storage layer
  instead of by digest alone. Before the fix, any owner who learned
  a share link (the raw token is the link itself — not a secret)
  could compute its SHA-256 and revoke it by hitting the endpoint
  under their own `recording_id` in the URL, enabling cross-owner
  share revocation. A mismatched `(recording_id, token_sha256)` pair
  now returns 404, making cross-owner revoke indistinguishable from
  a truly unknown digest.

### Fixed

- Recording id is now generated once in `RecordingService` and
  reused as the on-disk filename, the asciicast `telepair` block,
  and the DB primary key. Previously the storage layer minted its
  own id, so `RecordingRow.id` and `file_path` referred to
  different recordings and the TTL cleaner deleted the row but
  left the `.cast` file behind.
- Anonymous share playback works: `/recordings/:id/play` is now a
  dedicated route outside `AuthGuard`, so a recipient with a
  `?token=` link is not bounced to `/login`.
- Revoking a share link actually removes the row. The HTTP handler
  previously called `delete_share` with the SHA-256 digest from the
  UI, which the service then re-hashed before lookup; the
  `DELETE … WHERE token_sha256 = ?` saw nothing and returned 204
  while the link kept working.
- Recording dimensions reflect the actual PTY size: the start
  handler now reads `(cols, rows)` from the live session instead of
  hardcoding `80×24`, and the PTY I/O loop keeps the size in sync
  on every resize.
- Writer-task I/O failures release the hub's recording slot so the
  owner can stop and restart recording in the same session — the
  previous behaviour stranded the slot bound to a dead writer until
  the session itself ended.
- Player seek uses `term.reset()` instead of `term.clear()` so
  rewinding does not stack the old run into the scrollback buffer.
- `stop_recording` no longer holds the sessions `RwLock` read guard
  across the `.send().await` to the writer — under back-pressure
  the previous code blocked every concurrent write-lock acquirer
  for the duration of the flush handshake.
- `DELETE /api/recordings/:id` refuses (409) while the recording is
  still being captured (`status = 'recording'`). The previous code
  removed the file and DB row from under the live writer, leaving a
  dangling file handle, wedging `stop_recording` into a 404, and
  keeping the hub's recording slot occupied until the session ended.
  File removal no longer proceeds when the status check fails, and
  IO errors other than `NotFound` bubble up so the DB row survives
  for a retry instead of leaving an orphan on disk.
- The TTL background cleaner excludes `status = 'recording'` rows
  from its expiry scan, belt-and-suspenders defence against a bad
  `expires_at` write or wall-clock jump handing it an active row.
- Recording writer marks the capture `failed` instead of `completed`
  when any PTY / collab events were dropped under back-pressure.
  Previously `try_send` failures were swallowed and the final status
  was always `completed`, so viewers could load a capture with
  invisible gaps. The hub's recording slot now bundles the mpsc
  sender with a shared `AtomicU64` drop counter, and the writer
  reads it at finalisation — a non-zero count flips the status and
  logs the drop total at `error!` level.

### Testing

- Cargo test count: **372 → 416** (all green). New coverage:
  `recording_test` (asciicast v2 encode/decode round-trip,
  `Recording` lifecycle, share-token hashing), `recording_storage_test`
  (atomic `UPDATE … RETURNING` consumption, TTL cleaner row+file
  parity, cross-recording token quota isolation, cross-owner share-
  revoke rejection, delete-while-active guard), and gateway-level
  REST coverage for the recording endpoints and access-control gates.
- Vitest count: **185 → 194** (all green). New coverage:
  `playback.test.ts` for the PlaybackEngine asciicast v2 parser and
  play/pause/seek/speed state machine.
- Playwright count: **44 → 51** (all green). New spec
  `recording.spec.ts` exercises the owner start/stop flow, the live
  indicator broadcast to peers, the share-link dialog, and the
  anonymous `?token=` playback path outside `AuthGuard`.


---

## Test plan

- [x] `make all` passes locally (fmt-check, clippy, tsc, cargo 416 tests, vitest 194 tests, release bin, web bundle, playwright 51 e2e)
- [ ] CI green on merge commit to main
- [ ] After merge: tag `v0.1.8 -s` → Release workflow → `gh release create`